### PR TITLE
fix: improved service match labels

### DIFF
--- a/internal/annotations.go
+++ b/internal/annotations.go
@@ -14,7 +14,11 @@
 
 package internal
 
-import "slices"
+import (
+	"slices"
+
+	score "github.com/score-spec/score-go/types"
+)
 
 const (
 	AnnotationPrefix       = "k8s.score.dev/"
@@ -22,7 +26,11 @@ const (
 )
 
 func ListAnnotations(metadata map[string]interface{}) []string {
-	if a, ok := metadata["annotations"].(map[string]interface{}); ok {
+	a, ok := metadata["annotations"].(map[string]interface{})
+	if !ok {
+		a, ok = metadata["annotations"].(score.WorkloadMetadata)
+	}
+	if ok {
 		out := make([]string, 0, len(a))
 		for s, _ := range a {
 			out = append(out, s)
@@ -34,7 +42,11 @@ func ListAnnotations(metadata map[string]interface{}) []string {
 }
 
 func FindAnnotation(metadata map[string]interface{}, annotation string) (string, bool) {
-	if a, ok := metadata["annotations"].(map[string]interface{}); ok {
+	a, ok := metadata["annotations"].(map[string]interface{})
+	if !ok {
+		a, ok = metadata["annotations"].(score.WorkloadMetadata)
+	}
+	if ok {
 		if v, ok := a[annotation].(string); ok {
 			return v, true
 		}

--- a/internal/project/state.go
+++ b/internal/project/state.go
@@ -30,12 +30,16 @@ const (
 	StateFileName                 = "state.yaml"
 )
 
+type WorkloadExtras struct {
+	InstanceSuffix string `yaml:"instance_suffix"`
+}
+
 type ResourceExtras struct {
 	// Don't actually persist these manifests, we just hold them here so we can pass them around.
 	Manifests []map[string]interface{} `yaml:"-"`
 }
 
-type State = framework.State[framework.NoExtras, framework.NoExtras, ResourceExtras]
+type State = framework.State[framework.NoExtras, WorkloadExtras, ResourceExtras]
 
 // The StateDirectory holds the local state of the score-k8s project, including any configuration, extensions,
 // plugins, or resource provisioning state when possible.

--- a/internal/provisioners/default/zz-default.provisioners.yaml
+++ b/internal/provisioners/default/zz-default.provisioners.yaml
@@ -42,7 +42,7 @@
     - apiVersion: v1
       kind: ConfigMap
       metadata:
-        name: {{ .Uid }}
+        name: cfg-{{ .Guid }}
         annotations:
           k8s.score.dev/source-workload: {{ .SourceWorkload }}
           k8s.score.dev/resource-uid: {{ .Uid }}
@@ -85,7 +85,6 @@
 - uri: template://default-provisioners/route
   type: route
   init: |
-    randomRouteName: routing-{{ .SourceWorkload }}-{{ randAlphaNum 6 | lower }}
     {{ if not (regexMatch "^/|(/([^/]+))+$" .Params.path) }}{{ fail "params.path start with a / but cannot end with /" }}{{ end }}
     {{ if not (regexMatch "^[a-z0-9_.-]{1,253}$" .Params.host) }}{{ fail (cat "params.host must be a valid hostname but was" .Params.host) }}{{ end }}
     {{ $ports := (index .WorkloadServices .SourceWorkload).Ports }}
@@ -93,7 +92,7 @@
     {{ $port := index $ports (print .Params.port) }}
     {{ if not $port.TargetPort }}{{ fail "params.port is not a named service port" }}{{ end }}
   state: |
-    routeName: {{ dig "routeName" .Init.randomRouteName .State | quote }}
+    routeName: route-{{ .SourceWorkload }}-{{ substr 0 8 .Guid | lower }}
   manifests: |
     - apiVersion: gateway.networking.k8s.io/v1
       kind: HTTPRoute
@@ -103,6 +102,10 @@
           k8s.score.dev/source-workload: {{ .SourceWorkload }}
           k8s.score.dev/resource-uid: {{ .Uid }}
           k8s.score.dev/resource-guid: {{ .Guid }}
+        labels:
+          app.kubernetes.io/managed-by: score-k8s
+          app.kubernetes.io/name: {{ .State.routeName }}
+          app.kubernetes.io/instance: {{ .State.routeName }}
       spec:
         parentRefs:
         - name: default
@@ -120,12 +123,11 @@
 - uri: template://default-provisioners/postgres
   type: postgres
   init: |
-    randomServiceName: pg-{{ randAlphaNum 6 | lower }}
     randomDatabase: db-{{ randAlpha 8 }}
     randomUsername: user-{{ randAlpha 8 }}
     randomPassword: {{ randAlphaNum 16 | quote }}
   state: |
-    service: {{ dig "service" .Init.randomServiceName .State | quote }}
+    service: pg-{{ .SourceWorkload }}-{{ substr 0 8 .Guid | lower }}
     database: {{ dig "database" .Init.randomDatabase .State | quote }}
     username: {{ dig "username" .Init.randomUsername .State | quote }}
     password: {{ dig "password" .Init.randomPassword .State | quote }}
@@ -145,6 +147,10 @@
           k8s.score.dev/source-workload: {{ .SourceWorkload }}
           k8s.score.dev/resource-uid: {{ .Uid }}
           k8s.score.dev/resource-guid: {{ .Guid }}
+        labels:
+          app.kubernetes.io/managed-by: score-k8s
+          app.kubernetes.io/name: {{ .State.service }}
+          app.kubernetes.io/instance: {{ .State.service }}
       data:
         password: {{ .State.password | b64enc }}
     - apiVersion: apps/v1
@@ -155,18 +161,22 @@
           k8s.score.dev/source-workload: {{ .SourceWorkload }}
           k8s.score.dev/resource-uid: {{ .Uid }}
           k8s.score.dev/resource-guid: {{ .Guid }}
+        labels:
+          app.kubernetes.io/managed-by: score-k8s
+          app.kubernetes.io/name: {{ .State.service }}
+          app.kubernetes.io/instance: {{ .State.service }}
       spec:
         replicas: 1
         serviceName: {{ .State.service }}
         selector:
           matchLabels:
-            scoreWorkload: {{ .SourceWorkload }}
-            app: {{ .State.service }}
+            app.kubernetes.io/instance: {{ .State.service }}
         template:
           metadata:
             labels:
-              scoreWorkload: {{ .SourceWorkload }}
-              app: {{ .State.service }}
+              app.kubernetes.io/managed-by: score-k8s
+              app.kubernetes.io/name: {{ .State.service }}
+              app.kubernetes.io/instance: {{ .State.service }}
             annotations:
               k8s.score.dev/source-workload: {{ .SourceWorkload }}
               k8s.score.dev/resource-uid: {{ .Uid }}
@@ -207,6 +217,10 @@
               k8s.score.dev/source-workload: {{ .SourceWorkload }}
               k8s.score.dev/resource-uid: {{ .Uid }}
               k8s.score.dev/resource-guid: {{ .Guid }}
+            labels:
+              app.kubernetes.io/managed-by: score-k8s
+              app.kubernetes.io/name: {{ .State.service }}
+              app.kubernetes.io/instance: {{ .State.service }}
           spec:
             accessModes: ["ReadWriteOnce"]
             resources:
@@ -220,10 +234,13 @@
           k8s.score.dev/source-workload: {{ .SourceWorkload }}
           k8s.score.dev/resource-uid: {{ .Uid }}
           k8s.score.dev/resource-guid: {{ .Guid }}
+        labels:
+          app.kubernetes.io/managed-by: score-k8s
+          app.kubernetes.io/name: {{ .State.service }}
+          app.kubernetes.io/instance: {{ .State.service }}
       spec:
         selector:
-          scoreWorkload: {{ .SourceWorkload }}
-          app: {{ .State.service }}
+          app.kubernetes.io/instance: {{ .State.service }}
         type: ClusterIP
         ports:
         - port: 5432
@@ -232,10 +249,9 @@
 - uri: template://default-provisioners/redis
   type: redis
   init: |
-    randomServiceName: redis-{{ randAlphaNum 6 | lower }}
     randomPassword: {{ randAlphaNum 16 | quote }}
   state: |
-    service: {{ dig "service" .Init.randomServiceName .State | quote }}
+    service: redis-{{ .SourceWorkload }}-{{ substr 0 8 .Guid | lower }}
     username: default
     password: {{ dig "password" .Init.randomPassword .State | quote }}
   outputs: |
@@ -252,6 +268,10 @@
           k8s.score.dev/source-workload: {{ .SourceWorkload }}
           k8s.score.dev/resource-uid: {{ .Uid }}
           k8s.score.dev/resource-guid: {{ .Guid }}
+        labels:
+          app.kubernetes.io/managed-by: score-k8s
+          app.kubernetes.io/name: {{ .State.service }}
+          app.kubernetes.io/instance: {{ .State.service }}
       data:
         password: {{ .State.password | b64enc }}
         redis.conf: {{ printf "requirepass %s\nport 6379\nsave 60 1\nloglevel warning\n" .State.password | b64enc }}
@@ -263,18 +283,22 @@
           k8s.score.dev/source-workload: {{ .SourceWorkload }}
           k8s.score.dev/resource-uid: {{ .Uid }}
           k8s.score.dev/resource-guid: {{ .Guid }}
+        labels:
+          app.kubernetes.io/managed-by: score-k8s
+          app.kubernetes.io/name: {{ .State.service }}
+          app.kubernetes.io/instance: {{ .State.service }}
       spec:
         replicas: 1
         serviceName: {{ .State.service }}
         selector:
           matchLabels:
-            scoreWorkload: {{ .SourceWorkload }}
-            app: {{ .State.service }}
+            app.kubernetes.io/instance: {{ .State.service }}
         template:
           metadata:
             labels:
-              scoreWorkload: {{ .SourceWorkload }}
-              app: {{ .State.service }}
+              app.kubernetes.io/managed-by: score-k8s
+              app.kubernetes.io/name: {{ .State.service }}
+              app.kubernetes.io/instance: {{ .State.service }}
             annotations:
               k8s.score.dev/source-workload: {{ .SourceWorkload }}
               k8s.score.dev/resource-uid: {{ .Uid }}
@@ -311,6 +335,10 @@
               k8s.score.dev/source-workload: {{ .SourceWorkload }}
               k8s.score.dev/resource-uid: {{ .Uid }}
               k8s.score.dev/resource-guid: {{ .Guid }}
+            labels:
+              app.kubernetes.io/managed-by: score-k8s
+              app.kubernetes.io/name: {{ .State.service }}
+              app.kubernetes.io/instance: {{ .State.service }}
           spec:
             accessModes: ["ReadWriteOnce"]
             resources:
@@ -324,10 +352,13 @@
           k8s.score.dev/source-workload: {{ .SourceWorkload }}
           k8s.score.dev/resource-uid: {{ .Uid }}
           k8s.score.dev/resource-guid: {{ .Guid }}
+        labels:
+          app.kubernetes.io/managed-by: score-k8s
+          app.kubernetes.io/name: {{ .State.service }}
+          app.kubernetes.io/instance: {{ .State.service }}
       spec:
         selector:
-          scoreWorkload: {{ .SourceWorkload }}
-          app: {{ .State.service }}
+          app.kubernetes.io/instance: {{ .State.service }}
         type: ClusterIP
         ports:
         - port: 6379

--- a/main_init.go
+++ b/main_init.go
@@ -61,7 +61,7 @@ potentially sensitive data and raw secrets, so this should not be checked into g
 			sd = &project.StateDirectory{
 				Path: project.DefaultRelativeStateDirectory,
 				State: project.State{
-					Workloads:   map[string]framework.ScoreWorkloadState[framework.NoExtras]{},
+					Workloads:   map[string]framework.ScoreWorkloadState[project.WorkloadExtras]{},
 					Resources:   map[framework.ResourceUid]framework.ScoreResourceState[project.ResourceExtras]{},
 					SharedState: map[string]interface{}{},
 				},

--- a/main_init_test.go
+++ b/main_init_test.go
@@ -115,7 +115,7 @@ func TestInitNominal_run_twice(t *testing.T) {
 	assert.NoError(t, err)
 	if assert.True(t, ok) {
 		assert.Equal(t, project.DefaultRelativeStateDirectory, sd.Path)
-		assert.Equal(t, map[string]framework.ScoreWorkloadState[framework.NoExtras]{}, sd.State.Workloads)
+		assert.Equal(t, map[string]framework.ScoreWorkloadState[project.WorkloadExtras]{}, sd.State.Workloads)
 		assert.Equal(t, map[framework.ResourceUid]framework.ScoreResourceState[project.ResourceExtras]{}, sd.State.Resources)
 		assert.Equal(t, map[string]interface{}{}, sd.State.SharedState)
 	}


### PR DESCRIPTION
While working with dapr I found the following issues: 

1. The match expressions could be simplified to match labels - and making it compatible with Dapr.