### PR TITLE
fix(convert): fixed panic in resource limits conversion

### DIFF
--- a/internal/convert/container_resources.go
+++ b/internal/convert/container_resources.go
@@ -30,6 +30,8 @@ func convertContainerResources(resources *scoretypes.ContainerResources) (coreV1
 			if err != nil {
 				return out, errors.Wrap(err, "requests: failed to convert")
 			}
+		}
+		if resources.Limits != nil {
 			out.Limits, err = buildResourceList(resources.Limits)
 			if err != nil {
 				return out, errors.Wrap(err, "limits: failed to convert")

--- a/internal/convert/container_resources_test.go
+++ b/internal/convert/container_resources_test.go
@@ -56,3 +56,17 @@ func Test_convertContainerResources_nominal(t *testing.T) {
 		},
 	}, rl)
 }
+
+func Test_convertContainerResources_partial(t *testing.T) {
+	rl, err := convertContainerResources(&scoretypes.ContainerResources{
+		Limits: &scoretypes.ResourcesLimits{
+			Memory: internal.Ref("20Mi"),
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, coreV1.ResourceRequirements{
+		Limits: map[coreV1.ResourceName]resource.Quantity{
+			"memory": resource.MustParse("20Mi"),
+		},
+	}, rl)
+}


### PR DESCRIPTION
Hit a panic when converting a resources section that had resource requests but no limits.

This PR fixes it and adds a regression test.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1031c3870]

goroutine 1 [running]:
github.com/score-spec/score-k8s/internal/convert.buildResourceList(0x0)
	/home/runner/work/score-k8s/score-k8s/internal/convert/container_resources.go:45 +0x30
github.com/score-spec/score-k8s/internal/convert.convertContainerResources(0x14000498420)
	/home/runner/work/score-k8s/score-k8s/internal/convert/container_resources.go:33 +0x5c
github.com/score-spec/score-k8s/internal/convert.ConvertWorkload(0x1400049dc00, {0x1400061e2b0, 0xd})
	/home/runner/work/score-k8s/score-k8s/internal/convert/workloads.go:90 +0x730
main.init.func2(0x103ad40e0, {0x1400033a640, 0x2, 0x2})
	/home/runner/work/score-k8s/score-k8s/main_generate.go:206 +0xd44
github.com/spf13/cobra.(*Command).execute(0x103ad40e0, {0x1400033a600, 0x2, 0x2})
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0x840
github.com/spf13/cobra.(*Command).ExecuteC(0x103ad3e00)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
main.main()
	/home/runner/work/score-k8s/score-k8s/main.go:63 +0x24
```
