### PR TITLE
feat(provisioners): added default mysql provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ Generally, users will want to copy in the provisioners files that work with thei
 
 For details of how the standard "template" provisioner works, see the `template://example-provisioners/example-provisioner` provisioner [here](internal/provisioners/default/zz-default.provisioners.yaml). For details of how the standard "cmd" provisioner works, see the `cmd://bash#example-provisioner` provisioner [here](internal/provisioners/default/zz-default.provisioners.yaml).
 
+## Provisioner support
+
+`score-k8s` comes with out-of-the-box support for:
+
+| Type          | Class   | Params                 | Output                                                                                                                                                          |
+| ------------- | ------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| volume        | default | (none)                 | `source`                                                                                                                                                        |
+| redis         | default | (none)                 | `host`, `port`, `username`, `password`                                                                                                                          |
+| postgres      | default | (none)                 | `host`, `port`, `name` (aka `database`), `username`, `password`                                                                                                 |
+| mysql         | default | (none)                 | `host`, `port`, `name` (aka `database`), `username`, `password`                                                                                                 |
+| dns           | default | (none)                 | `host`                                                                                                                                                          |
+| route         | default | `host`, `path`, `port` |                                                                                                                                                                 |
+
+Users are encouraged to write their own custom provisioners to support new resource types or to modify the implementations above.
+
 ## Usage
 
 ### Installation

--- a/internal/provisioners/default/zz-default.provisioners.yaml
+++ b/internal/provisioners/default/zz-default.provisioners.yaml
@@ -363,3 +363,134 @@
         ports:
         - port: 6379
           targetPort: 6379
+
+- uri: template://default-provisioners/mysql
+  type: mysql
+  init: |
+    randomDatabase: db-{{ randAlpha 8 }}
+    randomUsername: user-{{ randAlpha 8 }}
+    randomPassword: {{ randAlphaNum 16 | quote }}
+  state: |
+    service: mysql-{{ .SourceWorkload }}-{{ substr 0 8 .Guid | lower }}
+    database: {{ dig "database" .Init.randomDatabase .State | quote }}
+    username: {{ dig "username" .Init.randomUsername .State | quote }}
+    password: {{ dig "password" .Init.randomPassword .State | quote }}
+  outputs: |
+    host: {{ .State.service }}
+    port: 3306
+    name: {{ .State.database }}
+    database: {{ .State.database }}
+    username: {{ .State.username }}
+    password: {{ encodeSecretRef .State.service "MYSQL_PASSWORD" }}
+  manifests: |
+    - apiVersion: v1
+      kind: Secret
+      metadata:
+        name: {{ .State.service }}
+        annotations:
+          k8s.score.dev/source-workload: {{ .SourceWorkload }}
+          k8s.score.dev/resource-uid: {{ .Uid }}
+          k8s.score.dev/resource-guid: {{ .Guid }}
+        labels:
+          app.kubernetes.io/managed-by: score-k8s
+          app.kubernetes.io/name: {{ .State.service }}
+          app.kubernetes.io/instance: {{ .State.service }}
+      data:
+        MYSQL_PASSWORD: {{ .State.password | b64enc }}
+        MYSQL_ROOT_PASSWORD: {{ .State.password | b64enc }}
+    - apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: {{ .State.service }}
+        annotations:
+          k8s.score.dev/source-workload: {{ .SourceWorkload }}
+          k8s.score.dev/resource-uid: {{ .Uid }}
+          k8s.score.dev/resource-guid: {{ .Guid }}
+        labels:
+          app.kubernetes.io/managed-by: score-k8s
+          app.kubernetes.io/name: {{ .State.service }}
+          app.kubernetes.io/instance: {{ .State.service }}
+      spec:
+        replicas: 1
+        serviceName: {{ .State.service }}
+        selector:
+          matchLabels:
+            app.kubernetes.io/instance: {{ .State.service }}
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/managed-by: score-k8s
+              app.kubernetes.io/name: {{ .State.service }}
+              app.kubernetes.io/instance: {{ .State.service }}
+            annotations:
+              k8s.score.dev/source-workload: {{ .SourceWorkload }}
+              k8s.score.dev/resource-uid: {{ .Uid }}
+              k8s.score.dev/resource-guid: {{ .Guid }}
+          spec:
+            containers:
+            - name: mysql-db
+              image: mysql:8.0
+              ports:
+              - name: mysql
+                containerPort: 3306
+              env:
+              - name: MYSQL_USER
+                value: {{ .State.username | quote }}
+              - name: MYSQL_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ .State.service }}
+                    key: MYSQL_PASSWORD
+              - name: MYSQL_ROOT_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ .State.service }}
+                    key: MYSQL_ROOT_PASSWORD
+              - name: MYSQL_DATABASE
+                value: {{ .State.database | quote }}
+              volumeMounts:
+              - name: data
+                mountPath: /var/lib/mysql
+              readinessProbe:
+                exec:
+                  command: 
+                  - mysqladmin
+                  - ping
+                  - -h
+                  - localhost
+                periodSeconds: 3
+        volumeClaimTemplates:
+        - metadata:
+            name: data
+            annotations:
+              k8s.score.dev/source-workload: {{ .SourceWorkload }}
+              k8s.score.dev/resource-uid: {{ .Uid }}
+              k8s.score.dev/resource-guid: {{ .Guid }}
+            labels:
+              app.kubernetes.io/managed-by: score-k8s
+              app.kubernetes.io/name: {{ .State.service }}
+              app.kubernetes.io/instance: {{ .State.service }}
+          spec:
+            accessModes: ["ReadWriteOnce"]
+            resources:
+              requests:
+                storage: 1Gi
+    - apiVersion: v1
+      kind: Service
+      metadata:
+        name: {{ .State.service }}
+        annotations:
+          k8s.score.dev/source-workload: {{ .SourceWorkload }}
+          k8s.score.dev/resource-uid: {{ .Uid }}
+          k8s.score.dev/resource-guid: {{ .Guid }}
+        labels:
+          app.kubernetes.io/managed-by: score-k8s
+          app.kubernetes.io/name: {{ .State.service }}
+          app.kubernetes.io/instance: {{ .State.service }}
+      spec:
+        selector:
+          app.kubernetes.io/instance: {{ .State.service }}
+        type: ClusterIP
+        ports:
+        - port: 3306
+          targetPort: 3306


### PR DESCRIPTION
This copies the existing postgres provisioner and adapts it for mysql.

This was tested with a score file that looks like:

```
apiVersion: score.dev/v1b1
metadata:
    name: demo-app
containers:
    main:
        image: ghcr.io/astromechza/demo-app:v0.6.1
        variables:
            OVERRIDE_MYSQL: ${resources.db.username}:${resources.db.password}@tcp(${resources.db.host}:${resources.db.port})/${resources.db.name}
service:
    ports:
        web:
            port: 8080
resources:
    db:
        type: mysql
```

Which correctly verified that the database DSN for mysql was valid and connected ok.

Unlike score-compose, this provisioner uses a single database per instance model - which is generally ok for the moment as a proof of concept and providing some basic support.

Fixes #13 .