### PR TITLE
Add templating support to cmd provisioner

### DIFF
--- a/internal/provisioners/cmdprov/commandprov.go
+++ b/internal/provisioners/cmdprov/commandprov.go
@@ -94,6 +94,20 @@ func decodeBinary(uri string) (string, error) {
 }
 
 func (p *Provisioner) Provision(ctx context.Context, input *provisioners.Input) (*provisioners.ProvisionOutput, error) {
+	data := provisioners.TemplateData{
+		Guid:             input.ResourceGuid,
+		Uid:              input.ResourceUid,
+		Type:             input.ResourceType,
+		Class:            input.ResourceClass,
+		Id:               input.ResourceId,
+		Params:           input.ResourceParams,
+		Metadata:         input.ResourceMetadata,
+		State:            input.ResourceState,
+		Shared:           input.SharedState,
+		SourceWorkload:   input.SourceWorkload,
+		WorkloadServices: input.WorkloadServices,
+	}
+
 	bin, err := decodeBinary(p.Uri())
 	if err != nil {
 		return nil, err
@@ -111,6 +125,11 @@ func (p *Provisioner) Provision(ctx context.Context, input *provisioners.Input) 
 		if arg == "<mode>" {
 			args[i] = "provision"
 		}
+		rendered, err := provisioners.RenderTemplate(arg, data)
+		if err != nil {
+			return nil, err
+		}
+		args[i] = rendered
 	}
 
 	cmd := exec.CommandContext(ctx, bin, args...)

--- a/internal/provisioners/template.go
+++ b/internal/provisioners/template.go
@@ -1,0 +1,57 @@
+package provisioners
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
+	util "github.com/score-spec/score-k8s/internal"
+)
+
+// Data is the structure sent to each template during rendering.
+type TemplateData struct {
+	// Guid is a random uuid generated the first time this resource is added to the project.
+	Guid string
+
+	// Uid is the combined id like type.class#id
+	Uid string
+	// Type is always defined as the resource type
+	Type string
+	// Class is the resource class, it defaults to 'default'
+	Class string
+	// Id is the resource id, like 'global-id' or 'workload.res-name'
+	Id string
+
+	Params   map[string]interface{}
+	Metadata map[string]interface{}
+
+	Init   map[string]interface{}
+	State  map[string]interface{}
+	Shared map[string]interface{}
+
+	SourceWorkload   string
+	WorkloadServices map[string]NetworkService
+}
+
+func RenderTemplate(tpl string, data TemplateData) (string, error) {
+	if strings.TrimSpace(tpl) == "" {
+		return "", nil
+	}
+	prepared, err := template.New("").
+		Funcs(sprig.FuncMap()).
+		Funcs(template.FuncMap{"encodeSecretRef": util.EncodeSecretReference}).
+		Parse(tpl)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse template: %w", err)
+	}
+	buff := new(bytes.Buffer)
+	if err := prepared.Execute(buff, data); err != nil {
+		return "", fmt.Errorf("failed to execute template: %w", err)
+	}
+	if strings.TrimSpace(buff.String()) == "" {
+		return "", nil
+	}
+	return buff.String(), nil
+}

--- a/internal/provisioners/template_test.go
+++ b/internal/provisioners/template_test.go
@@ -1,0 +1,42 @@
+package provisioners_test
+
+import (
+	"testing"
+
+	"github.com/score-spec/score-k8s/internal/provisioners"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderTemplate_EmptyTemplate(t *testing.T) {
+	data := provisioners.TemplateData{}
+	out, err := provisioners.RenderTemplate("", data)
+	if !assert.Equal(t, "", out) && err == nil {
+		t.Errorf("expected error for empty template")
+	}
+}
+
+func TestRenderTemplate_RenderingWorks(t *testing.T) {
+	raw := "Hello {{ .Guid }}"
+	data := provisioners.TemplateData{
+		Guid: "some-guid",
+	}
+	out, err := provisioners.RenderTemplate(raw, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "Hello some-guid" {
+		t.Errorf("expected 'Hello some-guid', got %s", out)
+	}
+}
+
+func TestRenderTemplate_RenderingWorksWithInvalidTemplateSyntax(t *testing.T) {
+	raw := "Hello {{ invalid syntax }}"
+	data := provisioners.TemplateData{}
+	out, err := provisioners.RenderTemplate(raw, data)
+	if err == nil {
+		t.Errorf("expected error for invalid template syntax")
+	}
+	if !assert.Equal(t, "", out) && err != nil {
+		t.Errorf("unexpected output: %s", out)
+	}
+}


### PR DESCRIPTION
Here is my attempt at implementing templating support for cmd provisioner.

cmd provisioner arguments can now use the same templating facilities as template provider.
This is very useful in constructing arguments.

Let me know what you think!