### PR TITLE
fix: remove default replicas=1 value from workload conversion

### DIFF
--- a/internal/convert/workloads.go
+++ b/internal/convert/workloads.go
@@ -254,7 +254,6 @@ func ConvertWorkload(state *project.State, workloadName string) ([]machineryMeta
 				Labels:      commonLabels,
 			},
 			Spec: v1.StatefulSetSpec{
-				Replicas: internal.Ref(int32(1)),
 				Selector: &machineryMeta.LabelSelector{
 					MatchLabels: map[string]string{
 						SelectorLabelInstance: commonLabels[SelectorLabelInstance],

--- a/internal/convert/workloads.go
+++ b/internal/convert/workloads.go
@@ -209,7 +209,6 @@ func ConvertWorkload(state *project.State, workloadName string) ([]machineryMeta
 				Labels:      commonLabels,
 			},
 			Spec: v1.DeploymentSpec{
-				Replicas: internal.Ref(int32(1)),
 				Selector: &machineryMeta.LabelSelector{
 					MatchLabels: map[string]string{
 						SelectorLabelInstance: commonLabels[SelectorLabelInstance],

--- a/internal/convert/workloads_test.go
+++ b/internal/convert/workloads_test.go
@@ -173,7 +173,6 @@ metadata:
     app.kubernetes.io/name: example
   name: example
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: example-abcdef


### PR DESCRIPTION
This was mentioned in #25 as causing issues with deployments that have an HPA or have been scaled up by hand already. I'm not entirely sure why we had this default, possibly due to a previous proof of concept or example. Not breaking change since 1 is the default replicas. 

Thanks @maxstepanov for bringing this to our attention!