### PR TITLE
fix: reject --image when multiple score files are provided

### DIFF
--- a/main_generate.go
+++ b/main_generate.go
@@ -85,8 +85,8 @@ manifests. All resources and links between Workloads will be resolved and provis
 		}
 		state := &sd.State
 
-		if len(args) != 1 && (cmd.Flags().Lookup(generateCmdOverridesFileFlag).Changed || cmd.Flags().Lookup(generateCmdOverridePropertyFlag).Changed) {
-			return errors.Errorf("cannot use --%s or --%s when 0 or more than 1 score files are provided", generateCmdOverridePropertyFlag, generateCmdOverridesFileFlag)
+		if len(args) != 1 && (cmd.Flags().Lookup(generateCmdOverridesFileFlag).Changed || cmd.Flags().Lookup(generateCmdOverridePropertyFlag).Changed || cmd.Flags().Lookup(generateCmdImageFlag).Changed) {
+			return errors.Errorf("cannot use --%s, --%s, or --%s when 0 or more than 1 score files are provided", generateCmdOverridePropertyFlag, generateCmdOverridesFileFlag, generateCmdImageFlag)
 		}
 
 		slices.Sort(args)


### PR DESCRIPTION
Similar to https://github.com/score-spec/score-compose/issues/173 but for the k8s provided.