### PR TITLE
Improve error messaging on unsupported resource types. Closes issue #31

### DIFF
--- a/internal/provisioners/core.go
+++ b/internal/provisioners/core.go
@@ -216,7 +216,8 @@ func ProvisionResources(ctx context.Context, state *project.State, provisioners 
 			return provisioner.Match(resUid)
 		})
 		if provisionerIndex < 0 {
-			return nil, fmt.Errorf("resource '%s' is not supported by any provisioner", resUid)
+			return nil, fmt.Errorf("resource '%s' is not supported by any provisioner. "+
+				"Please implement a custom resource provisioner to support this resource type.", resUid)
 		}
 		provisioner := provisioners[provisionerIndex]
 		if resState.ProvisionerUri != "" && resState.ProvisionerUri != provisioner.Uri() {


### PR DESCRIPTION
Hello, this PR closes issue #31 by changing the error message from 

`Error: failed to provision resources: The resource 'environment.default#my-sample-workload.env' is not supported by any existing provisioner.`

to 

`Error: failed to provision resources: The resource 'environment.default#my-sample-workload.env' is not supported by any existing provisioner. Please implement a custom resource provisioner to support this resource type.`