### PR TITLE
Remove `-svc` suffix in `Service` name for more consistency

### DIFF
--- a/internal/annotations.go
+++ b/internal/annotations.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	AnnotationPrefix       = "k8s.score.dev/"
-	WorkloadKindAnnotation = AnnotationPrefix + "kind"
+	AnnotationPrefix              = "k8s.score.dev/"
+	WorkloadKindAnnotation        = AnnotationPrefix + "kind"
+	WorkloadServiceNameAnnotation = AnnotationPrefix + "service-name"
 )
 
 func ListAnnotations(metadata map[string]interface{}) []string {

--- a/internal/convert/workloads.go
+++ b/internal/convert/workloads.go
@@ -280,7 +280,10 @@ func ConvertWorkload(state *project.State, workloadName string) ([]machineryMeta
 }
 
 func WorkloadServiceName(workloadName string) string {
-	return fmt.Sprintf("%s", workloadName)
+	if d, ok := internal.FindAnnotation(spec.Metadata, internal.WorkloadServiceNameAnnotation); ok {
+		return d
+	}
+	return workloadName
 }
 
 func buildProbe(input scoretypes.HttpProbe) coreV1.ProbeHandler {

--- a/internal/convert/workloads.go
+++ b/internal/convert/workloads.go
@@ -229,7 +229,7 @@ func ConvertWorkload(state *project.State, workloadName string) ([]machineryMeta
 	case WorkloadKindStatefulSet:
 
 		// need to allocate a headless service here
-		headlessServiceName := fmt.Sprintf("%s-headless-svc", workloadName)
+		headlessServiceName := fmt.Sprintf("%s-headless", workloadName)
 		manifests = append(manifests, &coreV1.Service{
 			TypeMeta: machineryMeta.TypeMeta{Kind: "Service", APIVersion: "v1"},
 			ObjectMeta: machineryMeta.ObjectMeta{
@@ -280,7 +280,7 @@ func ConvertWorkload(state *project.State, workloadName string) ([]machineryMeta
 }
 
 func WorkloadServiceName(workloadName string) string {
-	return fmt.Sprintf("%s-svc", workloadName)
+	return fmt.Sprintf("%s", workloadName)
 }
 
 func buildProbe(input scoretypes.HttpProbe) coreV1.ProbeHandler {

--- a/internal/convert/workloads_test.go
+++ b/internal/convert/workloads_test.go
@@ -150,7 +150,7 @@ metadata:
     app.kubernetes.io/instance: example-abcdef
     app.kubernetes.io/managed-by: score-k8s
     app.kubernetes.io/name: example
-  name: example-svc
+  name: example
 spec:
   ports:
   - name: web


### PR DESCRIPTION
Remove `-svc` suffix in `Service` name for more consistency with `Deployment` name. Common pattern/naming out there.


Context, with this:
```
apiVersion: score.dev/v1b1
metadata:
  name: store-front
containers:
  store-front:
    image: .
    variables:
      VUE_APP_ORDER_SERVICE_URL: "http://${resources.order-service.name}:3000/"
resources:
  order-service:
    type: service
```

And this:
```
- uri: template://service-provisioners/static-service
  type: service
  init: |
    name: {{ splitList "." .Id | last }}
  outputs: |
    {{ $w := (index .WorkloadServices .Init.name) }}
    name: {{ $w.ServiceName | quote }}
```