### PR TITLE
Default `Service` name now as the `Workload`, removing the `-svc` suffix + new annotation to override it `k8s.score.dev/service-name`

### DIFF
--- a/internal/annotations.go
+++ b/internal/annotations.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	AnnotationPrefix       = "k8s.score.dev/"
-	WorkloadKindAnnotation = AnnotationPrefix + "kind"
+	AnnotationPrefix              = "k8s.score.dev/"
+	WorkloadKindAnnotation        = AnnotationPrefix + "kind"
+	WorkloadServiceNameAnnotation = AnnotationPrefix + "service-name"
 )
 
 func ListAnnotations(metadata map[string]interface{}) []string {

--- a/internal/convert/workloads.go
+++ b/internal/convert/workloads.go
@@ -186,7 +186,7 @@ func ConvertWorkload(state *project.State, workloadName string) ([]machineryMeta
 		manifests = append(manifests, &coreV1.Service{
 			TypeMeta: machineryMeta.TypeMeta{Kind: "Service", APIVersion: "v1"},
 			ObjectMeta: machineryMeta.ObjectMeta{
-				Name:        WorkloadServiceName(workloadName),
+				Name:        WorkloadServiceName(workloadName, spec.Metadata),
 				Annotations: topLevelAnnotations,
 				Labels:      commonLabels,
 			},
@@ -279,8 +279,11 @@ func ConvertWorkload(state *project.State, workloadName string) ([]machineryMeta
 	return manifests, nil
 }
 
-func WorkloadServiceName(workloadName string) string {
-	return fmt.Sprintf("%s-svc", workloadName)
+func WorkloadServiceName(workloadName string, specMetadata map[string]interface{}) string {
+	if d, ok := internal.FindAnnotation(specMetadata, internal.WorkloadServiceNameAnnotation); ok {
+		return d
+	}
+	return workloadName
 }
 
 func buildProbe(input scoretypes.HttpProbe) coreV1.ProbeHandler {

--- a/internal/convert/workloads_test.go
+++ b/internal/convert/workloads_test.go
@@ -150,7 +150,7 @@ metadata:
     app.kubernetes.io/instance: example-abcdef
     app.kubernetes.io/managed-by: score-k8s
     app.kubernetes.io/name: example
-  name: example-svc
+  name: example
 spec:
   ports:
   - name: web

--- a/internal/provisioners/core.go
+++ b/internal/provisioners/core.go
@@ -173,7 +173,7 @@ func buildWorkloadServices(state *project.State) map[string]NetworkService {
 	out := make(map[string]NetworkService, len(state.Workloads))
 	for workloadName, workloadState := range state.Workloads {
 		ns := NetworkService{
-			ServiceName: convert.WorkloadServiceName(workloadName),
+			ServiceName: convert.WorkloadServiceName(workloadName, state.Workloads[workloadName].Spec.Metadata),
 			Ports:       make(map[string]ServicePort),
 		}
 		if workloadState.Spec.Service != nil {


### PR DESCRIPTION
- Default `Service` name now as the `Workload`, removing the `-svc` suffix
- New annotation to override it: `k8s.score.dev/service-name`