### PR TITLE
`postgres:17-alpine` + `securityContext`

### DIFF
--- a/internal/provisioners/default/zz-default.provisioners.yaml
+++ b/internal/provisioners/default/zz-default.provisioners.yaml
@@ -182,13 +182,16 @@
               k8s.score.dev/resource-uid: {{ .Uid }}
               k8s.score.dev/resource-guid: {{ .Guid }}
           spec:
+            automountServiceAccountToken: false
             containers:
             - name: postgres-db
-              image: postgres:16
+              image: postgres:17-alpine
               ports:
               - name: postgres
                 containerPort: 5432
               env:
+              - name: PGDATA
+                value: /var/lib/postgresql/data/pgdata
               - name: POSTGRES_USER
                 value: {{ .State.username | quote }}
               - name: POSTGRES_PASSWORD
@@ -201,6 +204,14 @@
               volumeMounts:
               - name: pv-data
                 mountPath: /var/lib/postgresql/data
+              securityContext:
+                runAsUser: 1000
+                runAsGroup: 1000
+                allowPrivilegeEscalation: false
+                privileged: false
+                capabilities:
+                  drop:
+                    - ALL
               readinessProbe:
                 exec:
                   command:
@@ -210,6 +221,11 @@
                   - -d
                   - {{ .State.database | quote }}
                 periodSeconds: 3
+            securityContext:
+              runAsNonRoot: true
+              fsGroup: 1000
+              seccompProfile:
+                type: RuntimeDefault
         volumeClaimTemplates:
         - metadata:
             name: pv-data


### PR DESCRIPTION
More security for the default `postgres` provisioner:
- `postgres:17-alpine`
- `securityContext`
- `automountServiceAccountToken=false`

Tested with this app: https://github.com/score-spec/sample-score-app.

`k get pods`:
```
NAME                           READY   STATUS    RESTARTS        AGE
hello-world-6bf94c85dc-h54rl   1/1     Running   3 (9m38s ago)   9m55s
pg-hello-world-edea9043-0      1/1     Running   0               9m57s
```

`curl $(score-k8s resources get-outputs dns.default#hello-world.dns --format '{{ .host }}')`:
```
  <html>
    <body>
      <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
      <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
      <div class="container text-center mt-5 pt-5">
        <h1>Hello, Kubernetes!</h1>
        <p>This is an application talking to a PostgreSQL <code>17.0</code> database on host <code>pg-hello-world-edea9043</code>, deployed with Score!</p>
        <p><code></p>
        <p>
          <pre>
          SELECT version();
          PostgreSQL 17.0 on x86_64-pc-linux-musl, compiled by gcc (Alpine 13.2.1_git20240309) 13.2.1 20240309, 64-bit
          </pre>
        </p>
      </div>
    </body>
  </html>
```