### PR TITLE
Update zz-default.provisioners.yaml - `securityContext` for `redis`

### DIFF
--- a/internal/provisioners/default/zz-default.provisioners.yaml
+++ b/internal/provisioners/default/zz-default.provisioners.yaml
@@ -320,9 +320,17 @@
               k8s.score.dev/resource-uid: {{ .Uid }}
               k8s.score.dev/resource-guid: {{ .Guid }}
           spec:
+            automountServiceAccountToken: false
             containers:
             - name: redis
               image: redis:7-alpine
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                privileged: false
+                readOnlyRootFilesystem: true
               ports:
               - name: redis
                 containerPort: 6379
@@ -337,6 +345,13 @@
                   - redis-cli
                   - ping
                 periodSeconds: 3
+            securityContext:
+              fsGroup: 1000
+              runAsGroup: 1000
+              runAsNonRoot: true
+              runAsUser: 1000
+              seccompProfile:
+                type: RuntimeDefault
             volumes:
             - name: config
               secret:


### PR DESCRIPTION
More security for the default `redis` provisioner:
- `securityContext`
- `automountServiceAccountToken=false`

Tested with this app: https://github.com/Humanitec-DemoOrg/onlineboutique-demo.