### PR TITLE
Update zz-default.provisioners.yaml - `securityContext` for `mongodb`

### DIFF
--- a/internal/provisioners/default/zz-default.provisioners.yaml
+++ b/internal/provisioners/default/zz-default.provisioners.yaml
@@ -573,6 +573,7 @@
               k8s.score.dev/resource-uid: {{ .Uid }}
               k8s.score.dev/resource-guid: {{ .Guid }}
           spec:
+            automountServiceAccountToken: false
             containers:
             - name: mongo-db
               image: mongo:latest
@@ -596,9 +597,28 @@
                 initialDelaySeconds: 30
                 timeoutSeconds: 5
                 periodSeconds: 20
+              securityContext:
+                runAsUser: 1001
+                runAsGroup: 1001
+                allowPrivilegeEscalation: false
+                privileged: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
               volumeMounts:
               - name: data
-                mountPath: /var/db
+                mountPath: /data/db
+              - name: tmp
+                mountPath: /tmp
+            securityContext:
+              runAsNonRoot: true
+              fsGroup: 1001
+              seccompProfile:
+                type: RuntimeDefault
+            volumes:
+              - name: tmp
+                emptyDir: {}
         volumeClaimTemplates:
         - metadata:
             name: data


### PR DESCRIPTION
More security for the default `mongodb` provisioner:
- `securityContext`
- `automountServiceAccountToken=false`

Tested with this app: https://github.com/Humanitec-DemoOrg/aks-store-demo.

`k get pods`:
```
NAME                                   READY   STATUS    RESTARTS   AGE
makeline-service-8c8765477-vg9tz       1/1     Running   0          70s
mongo-makeline-service-333c150c-0      1/1     Running   0          71s
order-service-6b49d7ff76-f7j8v         1/1     Running   0          70s
product-service-79c8d47575-vh5px       1/1     Running   0          69s
rabbitmq-makeline-service-4be9c8f3-0   1/1     Running   0          71s
store-admin-559f9f546b-6bmxg           1/1     Running   0          69s
store-front-54bc46cb96-nkzjc           1/1     Running   0          68s
```

`k logs makeline-service-8c8765477-vg9tz`:
```
2024/10/14 03:11:00 Using MongoDB API
[GIN-debug] [WARNING] Creating an Engine instance with the Logger and Recovery middleware already attached.

[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
 - using env:   export GIN_MODE=release
 - using code:  gin.SetMode(gin.ReleaseMode)

2024/10/14 03:11:22 pong from database
[GIN-debug] GET    /order/fetch              --> main.fetchOrders (5 handlers)
[GIN-debug] GET    /order/:id                --> main.getOrder (5 handlers)
[GIN-debug] PUT    /order                    --> main.updateOrder (5 handlers)
[GIN-debug] GET    /health                   --> main.main.func1 (5 handlers)
[GIN-debug] [WARNING] You trusted all proxies, this is NOT safe. We recommend you to set a value.
Please check https://pkg.go.dev/github.com/gin-gonic/gin#readme-don-t-trust-all-proxies for details.
[GIN-debug] Listening and serving HTTP on :3001
[GIN] 2024/10/14 - 03:11:26 | 200 |    6.402683ms |      10.244.0.1 | GET      "/health"
[GIN] 2024/10/14 - 03:11:26 | 200 |   31.749653ms |      10.244.0.1 | GET      "/health"
[GIN] 2024/10/14 - 03:11:36 | 200 |      45.956µs |      10.244.0.1 | GET      "/health"
[GIN] 2024/10/14 - 03:11:36 | 200 |      28.844µs |      10.244.0.1 | GET      "/health"
[GIN] 2024/10/14 - 03:11:46 | 200 |      55.563µs |      10.244.0.1 | GET      "/health"
[GIN] 2024/10/14 - 03:11:46 | 200 |      25.527µs |      10.244.0.1 | GET      "/health"
[GIN] 2024/10/14 - 03:11:56 | 200 |      40.786µs |      10.244.0.1 | GET      "/health"
[GIN] 2024/10/14 - 03:11:56 | 200 |      18.916µs |      10.244.0.1 | GET      "/health"
[GIN] 2024/10/14 - 03:12:06 | 200 |      43.071µs |      10.244.0.1 | GET      "/health"
[GIN] 2024/10/14 - 03:12:06 | 200 |       21.75µs |      10.244.0.1 | GET      "/health"
[GIN] 2024/10/14 - 03:12:16 | 200 |      38.612µs |      10.244.0.1 | GET      "/health"
[GIN] 2024/10/14 - 03:12:16 | 200 |       59.01µs |      10.244.0.1 | GET      "/health"
[GIN] 2024/10/14 - 03:12:26 | 200 |      38.352µs |      10.244.0.1 | GET      "/health"
[GIN] 2024/10/14 - 03:12:26 | 200 |      38.321µs |      10.244.0.1 | GET      "/health"
[GIN] 2024/10/14 - 03:12:36 | 200 |      39.234µs |      10.244.0.1 | GET      "/health"
[GIN] 2024/10/14 - 03:12:36 | 200 |     369.539µs |      10.244.0.1 | GET      "/health"
[GIN] 2024/10/14 - 03:12:46 | 200 |      39.714µs |      10.244.0.1 | GET      "/health"
[GIN] 2024/10/14 - 03:12:46 | 200 |      18.124µs |      10.244.0.1 | GET      "/health"
[GIN] 2024/10/14 - 03:12:56 | 200 |      40.987µs |      10.244.0.1 | GET      "/health"
[GIN] 2024/10/14 - 03:12:56 | 200 |      18.585µs |      10.244.0.1 | GET      "/health"
```