### PR TITLE
Create dependabot.yml and fix CI for push on main OR pull_request

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  #- package-ecosystem: "docker"
+  #  directory: "/"
+  #  schedule:
+  #    interval: "weekly"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,8 @@ name: release
 on:
   pull_request:
   push:
+    branches:
+      - 'main'
 
 permissions:
   contents: read


### PR DESCRIPTION
Create `dependabot.yml` to automate the process of upgrading go, Docker and GHA actions versions. This will avoid these manual actions needed in the past:
- https://github.com/score-spec/score-k8s/pull/41

Also took the opportunity to avoid the double run of the CI in a PR, so now CI (`release`) is triggered either on PR or in a push on `main`.