### PR TITLE
#57 Fix bug where score-k8s creates the score.yaml with perm 0600 instead of 0755

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,4 +42,4 @@ jobs:
         run: |
           docker run --rm score-k8s:test --version
           docker run -v .:/score-k8s --rm score-k8s:test init
-          ls | grep score.yaml
+          cat score.yaml

--- a/main_init.go
+++ b/main_init.go
@@ -126,7 +126,7 @@ the new provisioners will take precedence.
 						},
 					},
 				}
-				if f, err := os.OpenFile(initCmdScoreFile, os.O_CREATE|os.O_WRONLY, 0600); err != nil {
+				if f, err := os.OpenFile(initCmdScoreFile, os.O_CREATE|os.O_WRONLY, 0755); err != nil {
 					return errors.Wrap(err, "failed to open empty Score file")
 				} else {
 					defer f.Close()


### PR DESCRIPTION
Fix bug where score-k8s creates the score.yaml with perm 0600 instead of 0755.

<!--- Provide a general summary of your changes in the Title above -->

#### Description
Fix bug where score-k8s creates the score.yaml with perm 0600 instead of 0755. This is to keep it consistent with other commands like scope-compose which creates it with 0755 perm. Also the ci workflow has been changed to cat the file rather than listing it.

#### What does this PR do?
- Create score.yaml file with 0755 permissions
- Make the "Test Docker Image" CI to cat the file rather than listing it.



#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.