### PR TITLE
Added oci example in `score-k8s init --help`

### DIFF
--- a/main_init.go
+++ b/main_init.go
@@ -28,7 +28,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/score-spec/score-k8s/internal/project"
-	"github.com/score-spec/score-k8s/internal/provisioners/default"
+	_default "github.com/score-spec/score-k8s/internal/provisioners/default"
 	"github.com/score-spec/score-k8s/internal/provisioners/loader"
 )
 
@@ -158,7 +158,7 @@ the new provisioners will take precedence.
 			slog.Debug(fmt.Sprintf("Successfully loaded %d resource provisioners", len(provs)))
 		}
 
-		slog.Info(fmt.Sprintf("Read more about the Score specification at https://docs.score.dev/docs/"))
+		slog.Info("Read more about the Score specification at https://docs.score.dev/docs/")
 
 		return nil
 	},
@@ -167,7 +167,11 @@ the new provisioners will take precedence.
 func init() {
 	initCmd.Flags().StringP(initCmdFileFlag, "f", "score.yaml", "The score file to initialize")
 	initCmd.Flags().Bool(initCmdFileNoSampleFlag, false, "Disable generation of the sample score file")
-	initCmd.Flags().StringArray(initCmdProvisionerFlag, nil, "A provisioners file to install. May be specified multiple times. Supports http://host/file, https://host/file, git-ssh://git@host/repo.git/file, and  git-https://host/repo.git/file formats.")
-
+	initCmd.Flags().StringArray(initCmdProvisionerFlag, nil, "Provisioner files to install. May be specified multiple times. Supports:\n"+
+		"- HTTP        : http://host/file\n"+
+		"- HTTPS       : https://host/file\n"+
+		"- Git (SSH)   : git-ssh://git@host/repo.git/file\n"+
+		"- Git (HTTPS) : git-https://host/repo.git/file\n"+
+		"- OCI         : oci://[registry/][namespace/]repository[:tag|@digest]")
 	rootCmd.AddCommand(initCmd)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Added the OCI example as said in [here](https://github.com/score-spec/score-compose/issues/178)
#### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This pr added a new example and also fixed a typo.
<img width="995" alt="Screenshot 2024-10-20 at 2 44 00 AM" src="https://github.com/user-attachments/assets/189c3b67-9236-4dda-bf53-aba6d6f5ee71">

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.