### PR TITLE
Added a default service-port provisioner

### DIFF
--- a/internal/provisioners/default/zz-default.provisioners.yaml
+++ b/internal/provisioners/default/zz-default.provisioners.yaml
@@ -50,6 +50,21 @@
       data:
         key: {{ .Init.key }}
 
+# The default provisioner for service resources, this expects a workload and port name and will return the hostname and
+# port required to contact it. This will validate that the workload and port exist, but won't enforce a dependency
+# relationship yet.
+- uri: template://default-provisioners/service-port
+  type: service-port
+  outputs: |
+    {{ if not .Params.workload }}{{ fail "expected 'workload' param for the target workload name" }}{{ end }}
+    {{ if not .Params.port }}{{ fail "expected 'port' param for the name of the target workload service port" }}{{ end }}
+    {{ $w := (index .WorkloadServices .Params.workload) }}
+    {{ if not $w }}{{ fail "unknown workload" }}{{ end }}
+    {{ $p := (index $w.Ports .Params.port) }}
+    {{ if not $p }}{{ fail "unknown service port" }}{{ end }}
+    hostname: {{ $w.ServiceName | quote }}
+    port: {{ $p.TargetPort }}
+    
 # The 'cmd' scheme has a "host" + path component that indicates the path to the binary to execute. If the host starts
 # with "." it is interpreted as a relative path, if it starts with "~" it resolves to the home directory.
 - uri: cmd://bash#example-provisioner


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Added a default service-port provisioner for consistency as it is `score-compose` ..
#### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->



#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.