### PR TITLE
feature(provisioner) Add a default mssql provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For details of how the standard "template" provisioner works, see the `template:
 | route         | default | `host`, `path`, `port` |                                                                 |
 | mongodb       | default | (none)                 | `host`, `port`, `username`, `password`, `name`, `connection`    |
 | ampq          | default | (none)                 | `host`, `port`, `username`, `password`, `vhost`                 |
-| mssql         | default | (none)                 | `host`, `port`, `name` (aka `database`), `password` |
+| mssql         | default | (none)                 | `server`, `port`, `database`, `password`                        |
 
 Users are encouraged to write their own custom provisioners to support new resource types or to modify the implementations above.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ For details of how the standard "template" provisioner works, see the `template:
 | dns           | default | (none)                 | `host`                                                          |
 | route         | default | `host`, `path`, `port` |                                                                 |
 | mongodb       | default | (none)                 | `host`, `port`, `username`, `password`, `name`, `connection`    |
-| ampq          | default | (nont)                 | `host`, `port`, `username`, `password`, `vhost`                 |
+| ampq          | default | (none)                 | `host`, `port`, `username`, `password`, `vhost`                 |
+| mssql         | default | (none)                 | `host`, `port`, `name` (aka `database`), `password` |
 
 Users are encouraged to write their own custom provisioners to support new resource types or to modify the implementations above.
 

--- a/internal/provisioners/default/zz-default.provisioners.yaml
+++ b/internal/provisioners/default/zz-default.provisioners.yaml
@@ -798,3 +798,118 @@
         selector:
           app.kubernetes.io/instance: {{ .State.service }}
         type: ClusterIP
+
+- uri: template://default-provisioners/mssql
+  type: mssql
+  init: |
+    randomDatabase: db-{{ randAlpha 8 }}
+    randomPassword: {{ randAlphaNum 16 | quote }}
+  state: |
+    service: mssql-{{ .SourceWorkload }}-{{ substr 0 8 .Guid | lower }}
+    database: {{ dig "database" .Init.randomDatabase .State | quote }}
+    password: {{ dig "password" .Init.randomPassword .State | quote }}
+  outputs: |
+    host: {{ .State.service }}
+    port: 1433
+    name: {{ .State.database }}
+    password: {{ encodeSecretRef .State.service "MSSQL_SA_PASSWORD" }}
+  manifests: |
+    - apiVersion: v1
+      kind: Secret
+      metadata:
+        name: {{ .State.service }}
+        annotations:
+          k8s.score.dev/source-workload: {{ .SourceWorkload }}
+          k8s.score.dev/resource-uid: {{ .Uid }}
+          k8s.score.dev/resource-guid: {{ .Guid }}
+        labels:
+          app.kubernetes.io/managed-by: score-k8s
+          app.kubernetes.io/name: {{ .State.service }}
+          app.kubernetes.io/instance: {{ .State.service }}
+      data:
+        MSSQL_SA_PASSWORD: {{ .State.password | b64enc }}
+    - apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: {{ .State.service }}
+        annotations:
+          k8s.score.dev/source-workload: {{ .SourceWorkload }}
+          k8s.score.dev/resource-uid: {{ .Uid }}
+          k8s.score.dev/resource-guid: {{ .Guid }}
+        labels:
+          app.kubernetes.io/managed-by: score-k8s
+          app.kubernetes.io/name: {{ .State.service }}
+          app.kubernetes.io/instance: {{ .State.service }}
+      spec:
+        replicas: 1
+        serviceName: {{ .State.service }}
+        selector:
+          matchLabels:
+            app.kubernetes.io/instance: {{ .State.service }}
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/managed-by: score-k8s
+              app.kubernetes.io/name: {{ .State.service }}
+              app.kubernetes.io/instance: {{ .State.service }}
+            annotations:
+              k8s.score.dev/source-workload: {{ .SourceWorkload }}
+              k8s.score.dev/resource-uid: {{ .Uid }}
+              k8s.score.dev/resource-guid: {{ .Guid }}
+          spec:
+            containers:
+            - name: mssql-db
+              image: mcr.microsoft.com/mssql/server:latest
+              ports:
+              - name: mssql
+                containerPort: 1433
+              env:
+              - name: ACCEPT_EULA
+                value: "Y"
+              - name: MSSQL_ENABLE_HADR
+                value: "1"
+              - name: MSSQL_AGENT_ENABLED
+                value: "1"
+              - name: MSSQL_SA_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ .State.service }}
+                    key: MSSQL_SA_PASSWORD
+              volumeMounts:
+              - name: mssql
+                mountPath: "/var/opt/mssql"
+        volumeClaimTemplates:
+        - metadata:
+            name: mssql
+            annotations:
+              k8s.score.dev/source-workload: {{ .SourceWorkload }}
+              k8s.score.dev/resource-uid: {{ .Uid }}
+              k8s.score.dev/resource-guid: {{ .Guid }}
+            labels:
+              app.kubernetes.io/managed-by: score-k8s
+              app.kubernetes.io/name: {{ .State.service }}
+              app.kubernetes.io/instance: {{ .State.service }}
+          spec:
+            accessModes: ["ReadWriteOnce"]
+            resources:
+              requests:
+                storage: 1Gi
+    - apiVersion: v1
+      kind: Service
+      metadata:
+        name: {{ .State.service }}
+        annotations:
+          k8s.score.dev/source-workload: {{ .SourceWorkload }}
+          k8s.score.dev/resource-uid: {{ .Uid }}
+          k8s.score.dev/resource-guid: {{ .Guid }}
+        labels:
+          app.kubernetes.io/managed-by: score-k8s
+          app.kubernetes.io/name: {{ .State.service }}
+          app.kubernetes.io/instance: {{ .State.service }}
+      spec:
+        selector:
+          app.kubernetes.io/instance: {{ .State.service }}
+        type: ClusterIP
+        ports:
+        - port: 1433
+          targetPort: 1433

--- a/internal/provisioners/default/zz-default.provisioners.yaml
+++ b/internal/provisioners/default/zz-default.provisioners.yaml
@@ -807,11 +807,13 @@
   state: |
     service: mssql-{{ .SourceWorkload }}-{{ substr 0 8 .Guid | lower }}
     database: {{ dig "database" .Init.randomDatabase .State | quote }}
+    username: sa
     password: {{ dig "password" .Init.randomPassword .State | quote }}
   outputs: |
     host: {{ .State.service }}
     port: 1433
     name: {{ .State.database }}
+    username: {{ .State.username }}
     password: {{ encodeSecretRef .State.service "MSSQL_SA_PASSWORD" }}
   manifests: |
     - apiVersion: v1

--- a/internal/provisioners/default/zz-default.provisioners.yaml
+++ b/internal/provisioners/default/zz-default.provisioners.yaml
@@ -802,17 +802,17 @@
 - uri: template://default-provisioners/mssql
   type: mssql
   init: |
-    randomDatabase: db-{{ randAlpha 8 }}
     randomPassword: {{ randAlphaNum 16 | quote }}
   state: |
     service: mssql-{{ .SourceWorkload }}-{{ substr 0 8 .Guid | lower }}
-    database: {{ dig "database" .Init.randomDatabase .State | quote }}
+    database: master
     username: sa
     password: {{ dig "password" .Init.randomPassword .State | quote }}
   outputs: |
-    host: {{ .State.service }}
+    server: {{ .State.service }}
     port: 1433
-    name: {{ .State.database }}
+    connection: "Server=tcp:{{ .State.service }},1433;Initial Catalog={{ .State.database }};User ID={{ .State.username }};Password={{ encodeSecretRef .State.service "MSSQL_SA_PASSWORD" }}"
+    database: {{ .State.database }}
     username: {{ .State.username }}
     password: {{ encodeSecretRef .State.service "MSSQL_SA_PASSWORD" }}
   manifests: |


### PR DESCRIPTION
Adding a new default provider for a mssql database.

#### Description
Created a new default provider template for a mssql db based on already existing mysql and postgres ones. Updated zz-default.provisioners.yaml and README.md.

#### What does this PR do?
Adding a new default provider for a mssql database per feature request https://github.com/score-spec/score-k8s/issues/66

Was tested with the following score.yaml file:

```
apiVersion: score.dev/v1b1
metadata:
    name: test-container
containers:
    main:
        image: mcr.microsoft.com/mssql-tools
        variables:
            SERVER_NAME: ${resources.db.host}
            MSSQL_SA_USER: ${resources.db.username}
            MSSQL_SA_PASSWORD: ${resources.db.password}
        command:
            - /bin/sh
            - -c
            - /opt/mssql-tools/bin/sqlcmd -S $SERVER_NAME -U $MSSQL_SA_USER -P $MSSQL_SA_PASSWORD -Q "select @@version"
resources:
    db:
        type: mssql
```

Once deployed in a k3s cluster, the following was succesfully logged by the test-container:

```
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
Microsoft SQL Server 2022 (RTM-CU15-GDR) (KB5046059) - 16.0.4150.1 (X64)                                                                                                                                      
     Sep 25 2024 17:34:41                                                                                                                                                                                      
     Copyright (C) 2022 Microsoft Corporation                                                                                                                                                                  
     Developer Edition (64-bit) on Linux (Ubuntu 22.04.5 LTS) <X64>                                                                                                                                            
                                                                                                                                                                                                               
  (1 rows affected)
```


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I've signed off with an email address that matches the commit author.