### PR TITLE
Update zz-default.provisioners.yaml - `mysql:8`

### DIFF
--- a/internal/provisioners/default/zz-default.provisioners.yaml
+++ b/internal/provisioners/default/zz-default.provisioners.yaml
@@ -475,7 +475,7 @@
           spec:
             containers:
             - name: mysql-db
-              image: mysql:8.0
+              image: mysql:8
               ports:
               - name: mysql
                 containerPort: 3306


### PR DESCRIPTION
Like for `score-compose`, let's use `mysql:8` instead of `mysql:8.0` allowing to use `8.4.3` currently, latest LTS instead of `8.0.40`.

https://github.com/score-spec/score-compose/blob/main/internal/command/default.provisioners.yaml#L582