### PR TITLE
chore: enable ci on main push

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,10 @@
 name: ci
 on:
+  # We run the CI checks on any pull request updates or pushes to the main branch after PR merge.
   pull_request:
+  push:
+    branches:
+      - main
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
Get a confirmation signal on main branch merge.