### PR TITLE
Adding an s3 default provisioner based on minio

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ For details of how the standard "template" provisioner works, see the `template:
 | mongodb       | default | (none)                 | `host`, `port`, `username`, `password`, `name`, `connection`    |
 | ampq          | default | (none)                 | `host`, `port`, `username`, `password`, `vhost`                 |
 | mssql         | default | (none)                 | `server`, `port`, `database`, `password`                        |
+| s3            | default | (none)                 | `endpoint`, `region`, `bucket`, `access_key_id`, `secret_key`   |
 
 Users are encouraged to write their own custom provisioners to support new resource types or to modify the implementations above.
 

--- a/internal/convert/container_files.go
+++ b/internal/convert/container_files.go
@@ -41,7 +41,7 @@ func convertContainerFile(
 
 	var mountMode *int32
 	if fileElem.Mode != nil {
-		df, err := strconv.ParseInt(*fileElem.Mode, 10, 32)
+		df, err := strconv.ParseInt(*fileElem.Mode, 8, 32)
 		if err != nil {
 			return mount, nil, nil, errors.Wrapf(err, "mode: failed to parse '%s'", *fileElem.Mode)
 		}

--- a/internal/provisioners/default/zz-default.provisioners.yaml
+++ b/internal/provisioners/default/zz-default.provisioners.yaml
@@ -1063,6 +1063,7 @@
               - /bin/bash
               - -c
               - |
+                set -eu
                 mc alias set myminio http://{{ $service }}:9000 {{ $shared.instanceUsername | quote }} $MINIO_ROOT_PASSWORD
                 mc admin user svcacct info myminio {{ $shared.instanceAccessKeyId | quote }} || mc admin user svcacct add myminio {{ $shared.instanceUsername | quote }} --access-key {{ $shared.instanceAccessKeyId | quote }} --secret-key $MINIO_SECRET_KEY
                 mc mb -p myminio/{{ .State.bucket }}

--- a/internal/provisioners/default/zz-default.provisioners.yaml
+++ b/internal/provisioners/default/zz-default.provisioners.yaml
@@ -928,7 +928,7 @@
     bucket: {{ dig "bucket" (printf "bucket-%s" .Guid) .State | quote }}
   shared: |
     {{ .Init.sk }}:
-      instanceServiceName: {{ dig .Init.sk "instanceServiceName" (randAlpha 7 | printf "minio-%s") .Shared | quote }}
+      instanceServiceName: {{ dig .Init.sk "instanceServiceName" (randAlpha 7 | lower | printf "minio-%s") .Shared | quote }}
       instanceUsername: {{ dig .Init.sk "instanceUsername" (randAlpha 7 | printf "user-%s") .Shared | quote }}
       instancePassword: {{ dig .Init.sk "instancePassword" (randAlphaNum 16) .Shared | quote }}
       instanceAccessKeyId: {{ dig .Init.sk "instanceAccessKeyId" (randAlphaNum 20) .Shared | quote }}
@@ -969,7 +969,7 @@
             containers:
             - name: minio
               image:  quay.io/minio/minio
-              command: ["server", "/data", "--console-address", ":9001"]
+              args: ["server", "/data", "--console-address", ":9001"]
               ports:
               - name: service
                 containerPort: 9000
@@ -991,11 +991,38 @@
                 capabilities:
                   drop:
                     - ALL
+              volumeMounts:
+              - name: data
+                mountPath: /data
             securityContext:
               runAsNonRoot: true
+              runAsUser: 1000
+              runAsGroup: 1000
               fsGroup: 1000
               seccompProfile:
                 type: RuntimeDefault
+        volumeClaimTemplates:
+        - metadata:
+            name: data
+            labels:
+              app.kubernetes.io/managed-by: score-k8s
+              app.kubernetes.io/name: {{ $service | quote }}
+              app.kubernetes.io/instance: {{ $service | quote }}
+          spec:
+            accessModes: ["ReadWriteOnce"]
+            resources:
+              requests:
+                storage: 1Gi
+    - apiVersion: v1
+      kind: Secret
+      metadata:
+        name: {{ $service }}
+        labels:
+          app.kubernetes.io/managed-by: score-k8s
+          app.kubernetes.io/name: {{ $service }}
+          app.kubernetes.io/instance: {{ $service }}
+      data:
+        password: {{ dig .Init.sk "instancePassword" "" .Shared | b64enc }}
     - apiVersion: v1
       kind: Service
       metadata:
@@ -1009,7 +1036,9 @@
           app.kubernetes.io/instance: {{ $service }}
         type: ClusterIP
         ports:
-        - port: 9000
+        - name: service
+          port: 9000
           targetPort: 9000
-        - port: 9001
+        - name: console
+          port: 9001
           targetPort: 9001

--- a/internal/provisioners/default/zz-default.provisioners.yaml
+++ b/internal/provisioners/default/zz-default.provisioners.yaml
@@ -915,3 +915,101 @@
         ports:
         - port: 1433
           targetPort: 1433
+
+# This resource provides an in-cluster minio based S3 bucket with AWS-style credentials.
+# This provides some common and well known outputs that can be used with any generic AWS s3 client.
+- uri: template://default-provisioners/s3
+  type: s3
+  # The init template contains some initial seed data that can be used t needed.
+  init: |
+    randomBucket: bucket-{{ randAlpha 8 | lower }}-{{ .Id | lower | trunc 47 }}
+    sk: default-provisioners-minio-instance
+  state: |
+    bucket: {{ dig "bucket" (printf "bucket-%s" .Guid) .State | quote }}
+  shared: |
+    {{ .Init.sk }}:
+      instanceServiceName: {{ dig .Init.sk "instanceServiceName" (randAlpha 7 | printf "minio-%s") .Shared | quote }}
+      instanceUsername: {{ dig .Init.sk "instanceUsername" (randAlpha 7 | printf "user-%s") .Shared | quote }}
+      instancePassword: {{ dig .Init.sk "instancePassword" (randAlphaNum 16) .Shared | quote }}
+      instanceAccessKeyId: {{ dig .Init.sk "instanceAccessKeyId" (randAlphaNum 20) .Shared | quote }}
+      instanceSecretKey: {{ dig .Init.sk "instanceSecretKey" (randAlphaNum 40) .Shared | quote }}
+  outputs: |
+    bucket: {{ .State.bucket }}
+    access_key_id: {{ dig .Init.sk "instanceAccessKeyId" "" .Shared | quote }}
+    secret_key: {{ dig .Init.sk "instanceSecretKey" "" .Shared | quote }}
+    endpoint: http://{{ dig .Init.sk "instanceServiceName" "" .Shared }}:9000
+    # for compatibility with Humanitec's existing s3 resource
+    region: ""
+    aws_access_key_id: {{ dig .Init.sk "instanceAccessKeyId" "" .Shared | quote }}
+    aws_secret_key: {{ dig .Init.sk "instanceSecretKey" "" .Shared | quote }}
+  manifests: |
+    {{ $service := dig .Init.sk "instanceServiceName" "" .Shared }}
+    - apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: {{ $service | quote }}
+        labels:
+          app.kubernetes.io/managed-by: score-k8s
+          app.kubernetes.io/name: {{ $service | quote }}
+          app.kubernetes.io/instance: {{ $service | quote }}
+      spec:
+        replicas: 1
+        serviceName: {{ $service | quote }}
+        selector:
+          matchLabels:
+            app.kubernetes.io/instance: {{ $service | quote }}
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/managed-by: score-k8s
+              app.kubernetes.io/name: {{ $service | quote }}
+              app.kubernetes.io/instance: {{ $service | quote }}
+          spec:
+            automountServiceAccountToken: false
+            containers:
+            - name: minio
+              image:  quay.io/minio/minio
+              command: ["server", "/data", "--console-address", ":9001"]
+              ports:
+              - name: service
+                containerPort: 9000
+              - name: console
+                containerPort: 9001
+              env:
+              - name: MINIO_ROOT_USER
+                value: {{ dig .Init.sk "instanceUsername" "" .Shared | quote }}
+              - name: MINIO_ROOT_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $service | quote }}
+                    key: password
+              securityContext:
+                runAsUser: 1000
+                runAsGroup: 1000
+                allowPrivilegeEscalation: false
+                privileged: false
+                capabilities:
+                  drop:
+                    - ALL
+            securityContext:
+              runAsNonRoot: true
+              fsGroup: 1000
+              seccompProfile:
+                type: RuntimeDefault
+    - apiVersion: v1
+      kind: Service
+      metadata:
+        name: {{ $service }}
+        labels:
+          app.kubernetes.io/managed-by: score-k8s
+          app.kubernetes.io/name: {{ $service }}
+          app.kubernetes.io/instance: {{ $service }}
+      spec:
+        selector:
+          app.kubernetes.io/instance: {{ $service }}
+        type: ClusterIP
+        ports:
+        - port: 9000
+          targetPort: 9000
+        - port: 9001
+          targetPort: 9001

--- a/internal/provisioners/default/zz-default.provisioners.yaml
+++ b/internal/provisioners/default/zz-default.provisioners.yaml
@@ -918,11 +918,11 @@
 
 # This resource provides an in-cluster minio based S3 bucket with AWS-style credentials.
 # This provides some common and well known outputs that can be used with any generic AWS s3 client.
+# The outputs of the provisioner are a stateful set, a service, a secret, and a job per bucket.
 - uri: template://default-provisioners/s3
   type: s3
   # The init template contains some initial seed data that can be used t needed.
   init: |
-    randomBucket: bucket-{{ randAlpha 8 | lower }}-{{ .Id | lower | trunc 47 }}
     sk: default-provisioners-minio-instance
   state: |
     bucket: {{ dig "bucket" (printf "bucket-%s" .Guid) .State | quote }}
@@ -934,16 +934,19 @@
       instanceAccessKeyId: {{ dig .Init.sk "instanceAccessKeyId" (randAlphaNum 20) .Shared | quote }}
       instanceSecretKey: {{ dig .Init.sk "instanceSecretKey" (randAlphaNum 40) .Shared | quote }}
   outputs: |
+    {{ $shared := dig .Init.sk (dict) .Shared }}
+    {{ $service := $shared.instanceServiceName }}
     bucket: {{ .State.bucket }}
-    access_key_id: {{ dig .Init.sk "instanceAccessKeyId" "" .Shared | quote }}
-    secret_key: {{ dig .Init.sk "instanceSecretKey" "" .Shared | quote }}
-    endpoint: http://{{ dig .Init.sk "instanceServiceName" "" .Shared }}:9000
+    access_key_id: {{ $shared.instanceAccessKeyId | quote }}
+    secret_key: {{ encodeSecretRef $service "secret_key" }}
+    endpoint: http://{{ $service }}:9000
+    region: "us-east-1"
     # for compatibility with Humanitec's existing s3 resource
-    region: ""
-    aws_access_key_id: {{ dig .Init.sk "instanceAccessKeyId" "" .Shared | quote }}
-    aws_secret_key: {{ dig .Init.sk "instanceSecretKey" "" .Shared | quote }}
+    aws_access_key_id: {{ $shared.instanceAccessKeyId | quote }}
+    aws_secret_key: {{ encodeSecretRef $service "secret_key" }}
   manifests: |
-    {{ $service := dig .Init.sk "instanceServiceName" "" .Shared }}
+    {{ $shared := dig .Init.sk (dict) .Shared }}
+    {{ $service := $shared.instanceServiceName }}
     - apiVersion: apps/v1
       kind: StatefulSet
       metadata:
@@ -977,7 +980,7 @@
                 containerPort: 9001
               env:
               - name: MINIO_ROOT_USER
-                value: {{ dig .Init.sk "instanceUsername" "" .Shared | quote }}
+                value: {{ $shared.instanceUsername | quote }}
               - name: MINIO_ROOT_PASSWORD
                 valueFrom:
                   secretKeyRef:
@@ -1022,7 +1025,8 @@
           app.kubernetes.io/name: {{ $service }}
           app.kubernetes.io/instance: {{ $service }}
       data:
-        password: {{ dig .Init.sk "instancePassword" "" .Shared | b64enc }}
+        password: {{ $shared.instancePassword | b64enc }}
+        secret_key: {{ $shared.instanceSecretKey | b64enc }}
     - apiVersion: v1
       kind: Service
       metadata:
@@ -1042,3 +1046,34 @@
         - name: console
           port: 9001
           targetPort: 9001
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: {{ printf "%s-bucket-%s" $service .Guid }}
+        labels:
+          app.kubernetes.io/managed-by: score-k8s
+      spec:
+        template:
+          spec:
+            restartPolicy: OnFailure
+            containers:
+            - name: main
+              image: quay.io/minio/minio
+              command:
+              - /bin/bash
+              - -c
+              - |
+                mc alias set myminio http://{{ $service }}:9000 {{ $shared.instanceUsername | quote }} $MINIO_ROOT_PASSWORD
+                mc admin user svcacct info myminio {{ $shared.instanceAccessKeyId | quote }} || mc admin user svcacct add myminio {{ $shared.instanceUsername | quote }} --access-key {{ $shared.instanceAccessKeyId | quote }} --secret-key $MINIO_SECRET_KEY
+                mc mb -p myminio/{{ .State.bucket }}
+              env:
+              - name: MINIO_ROOT_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $service | quote }}
+                    key: password
+              - name: MINIO_SECRET_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $service | quote }}
+                    key: secret_key


### PR DESCRIPTION
Fixes: #65 

This PR brings some much needed compatibility with `score-compose` by adding an s3 bucket provisioner by default using an in-cluster object storage based on minio.

This follows the current best practises of k8s provisioner development:

1. A single minio instance is created with stateful set and PVC based data storage. The pods run as non-root.
2. A k8s Service is created routing both api and console ports to the minio instance.
3. An s3 bucket is created per `s3` resource. We intentionally use a shared access key across all buckets for now to match score-compose behavior.
4. All secret outputs are encoded as references to in-cluster secrets.

**testing**

This was tested with the following score file:

```
apiVersion: score.dev/v1b1
metadata:
    name: demo-app
containers:
    main:
        image: quay.io/minio/minio
        command: ["/bin/bash", "-c", "sleep 3600"]
        variables:
            S3_ENDPOINT: ${resources.bucket-a.endpoint}
            S3_BUCKET: ${resources.bucket-a.bucket}
            S3_ACCESS_KEY_ID: ${resources.bucket-a.access_key_id}
            S3_SECRET_KEY: ${resources.bucket-a.secret_key}
resources:
    bucket-a:
        type: s3
    bucket-b:
        type: s3
```

This started up a pod with the minio object storage client cli.

I could then run the following:

```
$ mc alias set myminio $S3_ENDPOINT $S3_ACCESS_KEY_ID $S3_SECRET_KEY
...
Added `myminio` successfully.
$ mc ls myminio
[2024-11-22 09:23:22 UTC]     0B bucket-087c173f-4d3f-4a6b-e637-68d3ac846c34/
[2024-11-22 09:23:22 UTC]     0B bucket-927541d4-cb81-43b6-9722-3c5cceb8e9c0/
$ mc ls myminio/$S3_BUCKET
$ mc put ./etc/hostname myminio/$S3_BUCKET
/etc/hostname:               26 B / 26 B ┃▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓┃ 695 B/s 0s
$ mc ls myminio/$S3_BUCKET
[2024-11-22 09:40:30 UTC]    26B STANDARD hostname
```

I've also tested it with the following score file that uses a duckdb s3 client: https://gist.github.com/astromechza/b5cedbce68dd0baa6252728ff1de9505