### PR TITLE
Update Dockerfile - pinned digest for base container images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Use the official Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.23.4 AS builder
+FROM golang:1.23.4@sha256:7ea4c9dcb2b97ff8ee80a67db3d44f98c8ffa0d191399197007d8459c1453041 AS builder
 
 # Set the current working directory inside the container.
 WORKDIR /go/src/github.com/score-spec/score-k8s
@@ -15,7 +15,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o /usr/local/bin/score-k8s ./cmd/score-k8s
 
 # We can use gcr.io/distroless/static since we don't rely on any linux libs or state, but we need ca-certificates to connect to https/oci with the init command.
-FROM gcr.io/distroless/static
+FROM gcr.io/distroless/static:530158861eebdbbf149f7e7e67bfe45eb433a35c@sha256:5c7e2b465ac6a2a4e5f4f7f722ce43b147dabe87cb21ac6c4007ae5178a1fa58
 
 # Set the current working directory inside the container.
 WORKDIR /score-k8s


### PR DESCRIPTION
Update Dockerfile - pinned digest for base container images:
- https://github.com/score-spec/score-k8s/security/code-scanning/14
- https://github.com/score-spec/score-k8s/security/code-scanning/13