### PR TITLE
chore: update go to 1.23.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/score-spec/score-k8s
 
-go 1.23.4
+go 1.23.5
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0


### PR DESCRIPTION
chore: update go to 1.23.5

For some reasons, Dependabot is not picking this up...
https://github.com/score-spec/score-k8s/blob/main/.github/dependabot.yml#L11