### PR TITLE
feat: new and easier secret reference schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,15 @@ Kubernetes is a complex environment to provide defaults for since there are so m
 
 The provisioner files are loaded in lexicographic order, the `zz` prefix helps to ensure that the defaults are loaded last and that any custom provisioners have precedence.
 
+### How can I write my own provisioner?
+
+Provisioners can be written as templates for score-k8s to evaluate or a command/script that will be called. Write a file following the conventions used in the example provisioners from [zz-default.provisioners.yaml](./internal/provisioners/default/zz-default.provisioners.yaml). Then add this to your project by running `score-k8s init --provisioners ./your-custom.provisioners.yaml`.
+
+Other resources can be found at:
+- https://github.com/score-spec/community-provisioners
+- https://score.dev/blog/writing-a-custom-score-compose-provisioner-for-apache-kafka/
+- `score-k8s init --help`
+
 ### Does score-k8s generate a Deployment or StatefulSet?
 
 `score-k8s` generates a Deployment by default or when the `k8s.score.dev/kind` workload metadata annotation is set to `Deployment`. If the annotation is set to `StatefulSet` it will generate a set and allow the use of claim templates as outputs from volume resources.
@@ -205,7 +214,7 @@ The provisioner files are loaded in lexicographic order, the `zz` prefix helps t
 
 Right now, no namespace is specified in the generated manifests so they will obey any `--namespace` passed to the `kubctl apply` command. All secret references are assumed to be in the same namespace as the workloads.
 
-### How do I test `score-k8s` with with `kind` (Kubernetes in docker)?
+### How do I test `score-k8s` with `kind` (Kubernetes in docker)?
 
 The main requirement is that the route resource provisioner assumes that the Gateway API implementation is available with a named Gateway "default".
 

--- a/internal/provisioners/default/zz-default.provisioners.yaml
+++ b/internal/provisioners/default/zz-default.provisioners.yaml
@@ -35,8 +35,11 @@
     nested:
       example: thing
     # Instead of returning secret outputs as plaintext. They can be embedded as reference to Kubernetes Secrets. When
-    # these are detected, they can be used in environment variables or file contents securely.
-    secret-reference: {{ encodeSecretRef "my-secret" "my-key" }}
+    # these are detected, they can be used in environment variables or file contents securely. The format is 
+    # 🔐💬<secret name>_<secret key name>💬🔐. For example, the next line refers to a secret created in the manifests.
+    secret-reference: 🔐💬secret-{{ .Guid }}_password💬🔐
+    # A template function also exists for generating these in the template provisioner.
+    secret-reference-alt: {{ encodeSecretRef (printf "secret-%s" .Guid) "password" }}
   # (Optional) The manifests template gets evaluated as a list of Kubernetes object manifests to be added to the output.
   manifests: |
     - apiVersion: v1
@@ -49,6 +52,20 @@
           k8s.score.dev/resource-guid: {{ .Guid }}
       data:
         key: {{ .Init.key }}
+    - apiVersion: v1
+      kind: Secret
+      metadata:
+        name: secret-{{ .Guid }}
+        annotations:
+          k8s.score.dev/source-workload: {{ .SourceWorkload }}
+          k8s.score.dev/resource-uid: {{ .Uid }}
+          k8s.score.dev/resource-guid: {{ .Guid }}
+        labels:
+          app.kubernetes.io/managed-by: score-k8s
+          app.kubernetes.io/name: {{ .State.service }}
+          app.kubernetes.io/instance: {{ .State.service }}
+      data:
+        password: {{ .State.password | b64enc }}
 
 # The 'cmd' scheme has a "host" + path component that indicates the path to the binary to execute. If the host starts
 # with "." it is interpreted as a relative path, if it starts with "~" it resolves to the home directory.
@@ -58,7 +75,7 @@
   id: specific
   # (Optional) additional args that the binary gets run with
   # If any of the args are '<mode>' it will be replaced with "provision"
-  args: ["-c", "echo '{\"resource_outputs\":{\"key\":\"value\"},\"manifests\":[]}'"]
+  args: ["-c", "echo '{\"resource_outputs\":{\"key\":\"value\",\"secret\":\"🔐💬mysecret_mykey💬🔐\"},\"manifests\":[]}'"]
 
 # The default provisioner for service resources, this expects a workload and port name and will return the hostname and
 # port required to contact it. This will validate that the workload and port exist, but won't enforce a dependency

--- a/internal/provisioners/default/zz-default.provisioners.yaml
+++ b/internal/provisioners/default/zz-default.provisioners.yaml
@@ -65,7 +65,7 @@
           app.kubernetes.io/name: {{ .State.service }}
           app.kubernetes.io/instance: {{ .State.service }}
       data:
-        password: {{ .State.password | b64enc }}
+        password: {{ b64enc "my-secret-password" }}
 
 # The 'cmd' scheme has a "host" + path component that indicates the path to the binary to execute. If the host starts
 # with "." it is interpreted as a relative path, if it starts with "~" it resolves to the home directory.

--- a/internal/secrets_test.go
+++ b/internal/secrets_test.go
@@ -24,13 +24,13 @@ func TestDecodeSecretReferences_nominal(t *testing.T) {
 	splits, refs, err := DecodeSecretReferences(
 		EncodeSecretReference("s1", "k1") + "thing" +
 			EncodeSecretReference("s2", "k2") +
-			EncodeSecretReference("s3", "k3"),
+			EncodeSecretReference("a.val1d-dns.subdomain", "a-val1d.k_y"),
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"", "thing", "", ""}, splits)
 	assert.Equal(t, []SecretRef{
 		{Name: "s1", Key: "k1"},
 		{Name: "s2", Key: "k2"},
-		{Name: "s3", Key: "k3"},
+		{Name: "a.val1d-dns.subdomain", Key: "a-val1d.k_y"},
 	}, refs)
 }


### PR DESCRIPTION
In conversation with @mathieu-benoit, we found that secret references were difficult to work with in bash-based command provisioners because of the lack of base64url encoding tools in many distros. Examining the secret and key spec in k8s shows that there is actually a limited set of possible characters none of which are particularly bad to encode — so we can actually drop the base64 encoding entirely. Note that we have to switch the separator character to `_` which can't be confused with valid characters in a secret name.

With this change, a bash based provisioner can now work with just:

```
- uri: cmd://bash#example-provisioner
  type: example-provisioner-resource
  class: default
  id: specific
  # (Optional) additional args that the binary gets run with
  # If any of the args are '<mode>' it will be replaced with "provision"
  args: ["-c", "echo '{\"resource_outputs\":{\"key\":\"value\",\"secret\":\"🔐💬mysecret_mykey💬🔐\"},\"manifests\":[]}'"]
```