### PR TITLE
feat: added --patch-templates and deprecated --patch-manifests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0
+	github.com/tidwall/sjson v1.2.5
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.32.2
 	k8s.io/apimachinery v0.32.2
@@ -38,6 +39,9 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
+	github.com/tidwall/gjson v1.18.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/net v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,16 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/patching/patching.go
+++ b/internal/patching/patching.go
@@ -1,0 +1,128 @@
+// Copyright 2025 Humanitec
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package patching
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
+	score "github.com/score-spec/score-go/types"
+	"github.com/tidwall/sjson"
+	"gopkg.in/yaml.v3"
+
+	"github.com/score-spec/score-k8s/internal/project"
+)
+
+type PatchOperation struct {
+	Op          string      `json:"op"`
+	Path        string      `json:"path"`
+	Value       interface{} `json:"value,omitempty"`
+	Description string      `json:"description,omitempty"`
+}
+
+func yamlRoundTrip[k any, v any](input *k) (*v, error) {
+	raw, err := yaml.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal input: %w", err)
+	}
+	var out *v
+	if err := yaml.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal input: %w", err)
+	}
+	return out, nil
+}
+
+type patchTemplateInput struct {
+	Manifests []map[string]interface{}
+	Workloads map[string]interface{}
+}
+
+func ValidatePatchTemplate(content string) error {
+	if _, err := template.New("").Funcs(sprig.FuncMap()).Parse(content); err != nil {
+		return fmt.Errorf("failed to parse template: %w", err)
+	}
+	return nil
+}
+
+func PatchServices(state *project.State, manifests []map[string]interface{}, rawTemplate string) ([]map[string]interface{}, error) {
+	tmpl, err := template.New("").Funcs(sprig.FuncMap()).Parse(rawTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse template: %w", err)
+	}
+	buff := &bytes.Buffer{}
+	workloadSpecs := make(map[string]score.Workload, len(state.Workloads))
+	for n, w := range state.Workloads {
+		workloadSpecs[n] = w.Spec
+	}
+	workloadInputs, err := yamlRoundTrip[map[string]score.Workload, map[string]interface{}](&workloadSpecs)
+	if err != nil {
+		return nil, err
+	}
+	if err := tmpl.Execute(buff, patchTemplateInput{
+		Workloads: *workloadInputs,
+		Manifests: manifests,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to execute template: %w", err)
+	}
+	var patches []PatchOperation
+	templatedPatches := strings.TrimSpace(buff.String())
+	if templatedPatches == "" {
+		return manifests, nil
+	}
+
+	yamlDecoder := yaml.NewDecoder(strings.NewReader(templatedPatches))
+	yamlDecoder.KnownFields(true)
+	if err := yamlDecoder.Decode(&patches); err != nil {
+		slog.Debug("Raw patch output", slog.String("raw", templatedPatches))
+		return nil, fmt.Errorf("failed to unmarshal patches from template execution output: %w", err)
+	}
+	jsonInput, _ := json.Marshal(manifests)
+	for i, p := range patches {
+		if slog.Default().Enabled(context.Background(), slog.LevelDebug) {
+			slog.Debug("Applying patch", slog.String("operation", p.Op), slog.String("path", p.Path), slog.Any("value", p.Value), slog.Any("description", p.Description))
+		} else {
+			desc := p.Description
+			if desc != "" {
+				desc = " (" + desc + ")"
+			}
+			slog.Info(fmt.Sprintf("Applying patch to %s%s", p.Path, desc))
+		}
+		switch p.Op {
+		case "set":
+			jsonInput, err = sjson.SetBytes(jsonInput, p.Path, p.Value)
+		case "delete":
+			jsonInput, err = sjson.DeleteBytes(jsonInput, p.Path)
+		default:
+			err = fmt.Errorf("unknown operation: %s", p.Op)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to perform patch operation %d: '%s '%s': %w", i+1, p.Op, p.Path, err)
+		}
+	}
+
+	var output []map[string]interface{}
+	decoder := json.NewDecoder(bytes.NewReader(jsonInput))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&output); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal patched output: %w", err)
+	}
+	return output, nil
+}

--- a/internal/project/state.go
+++ b/internal/project/state.go
@@ -30,6 +30,10 @@ const (
 	StateFileName                 = "state.yaml"
 )
 
+type StateExtras struct {
+	PatchingTemplates []string `yaml:"patching_templates"`
+}
+
 type WorkloadExtras struct {
 	InstanceSuffix string `yaml:"instance_suffix"`
 }
@@ -39,7 +43,7 @@ type ResourceExtras struct {
 	Manifests []map[string]interface{} `yaml:"-"`
 }
 
-type State = framework.State[framework.NoExtras, WorkloadExtras, ResourceExtras]
+type State = framework.State[StateExtras, WorkloadExtras, ResourceExtras]
 
 // The StateDirectory holds the local state of the score-k8s project, including any configuration, extensions,
 // plugins, or resource provisioning state when possible.


### PR DESCRIPTION
And based on the success of https://github.com/score-spec/score-compose/pull/276 in score-compose, I'm pleased to present the addition of the `--patch-templates` feature for `score-k8s`!

This can be used to:

* inject additional manifests
* modify properties on existing ones
* replace manifests with different kinds or CRDs

This addresses #25 and #35. As well as Slack requests like https://cloud-native.slack.com/archives/C07DXMABPC4/p1741769300965929

Tested through unit tests today. 

I've noted the deprecation of the previous, kind of useless, `--patch-manifests` CLI option which can be removed in the future.