### PR TITLE
Update zz-default.provisioners.yaml - rabbitmq:alpine

### DIFF
--- a/internal/provisioners/default/zz-default.provisioners.yaml
+++ b/internal/provisioners/default/zz-default.provisioners.yaml
@@ -760,7 +760,7 @@
           spec:
             containers:
               - name: rabbitmq
-                image: rabbitmq:3-management
+                image: rabbitmq:3-management-alpine
                 ports:
                   - name: amqp
                     containerPort: 5672


### PR DESCRIPTION
Smaller image by default for the `amqp` provisioner like we already have in `score-compose`: https://github.com/score-spec/score-compose/blob/main/internal/command/default.provisioners.yaml#L367.

Before: `261MB`, after: `178MB` --> `83MB` saved uncompressed on disk.