### PR TITLE
chore: added debug message to debug failed patch output

### DIFF
--- a/internal/patching/patching.go
+++ b/internal/patching/patching.go
@@ -122,6 +122,7 @@ func PatchServices(state *project.State, manifests []map[string]interface{}, raw
 	decoder := json.NewDecoder(bytes.NewReader(jsonInput))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&output); err != nil {
+		slog.Debug("Failed to decode patched output", slog.String("output", string(jsonInput)))
 		return nil, fmt.Errorf("failed to unmarshal patched output: %w", err)
 	}
 	return output, nil


### PR DESCRIPTION
cc @mathieu-benoit 

When we debug issues related to patching output, we need to indicate to users that they should run with `-vv` to debug this unmarshalling error. Since Go unmarshal errors are often quite opaque. We don't have a more useful schema to run this against.