### PR TITLE
Update zz-default.provisioners.yaml - `service-port` fail if not found

### DIFF
--- a/internal/provisioners/default/zz-default.provisioners.yaml
+++ b/internal/provisioners/default/zz-default.provisioners.yaml
@@ -96,7 +96,7 @@
   outputs: |
     {{ if not .Params.workload }}{{ fail "expected 'workload' param for the target workload name" }}{{ end }}
     {{ if not .Params.port }}{{ fail "expected 'port' param for the name of the target workload service port" }}{{ end }}
-    {{ $w := (index .WorkloadServices .Params.workload) }}
+    {{ if or (not $w) (not $w.ServiceName) }}{{ fail "unknown workload" }}{{ end }}
     {{ if not $w }}{{ fail "unknown workload" }}{{ end }}
     {{ $p := (index $w.Ports .Params.port) }}
     {{ if not $p }}{{ fail "unknown service port" }}{{ end }}


### PR DESCRIPTION
Update zz-default.provisioners.yaml - `service-port` fail if not found