### PR TITLE
Update Dockerfile - remove debug info from container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN go mod download
 
 # Copy the entire project and build it.
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-X github.com/score-spec/score-k8s/internal/version.Version=${VERSION}" -o /usr/local/bin/score-k8s ./cmd/score-k8s
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X github.com/score-spec/score-k8s/internal/version.Version=${VERSION}" -o /usr/local/bin/score-k8s ./cmd/score-k8s
 
 # We can use gcr.io/distroless/static since we don't rely on any linux libs or state, but we need ca-certificates to connect to https/oci with the init command.
 FROM gcr.io/distroless/static:530158861eebdbbf149f7e7e67bfe45eb433a35c@sha256:5c7e2b465ac6a2a4e5f4f7f722ce43b147dabe87cb21ac6c4007ae5178a1fa58


### PR DESCRIPTION
Update Dockerfile - remove debug info from container image, like done there https://github.com/score-spec/score-compose/pull/360.

https://pkg.go.dev/cmd/link:
- `-s`: Omit the symbol table and debug information.
- `-w`: Omit the DWARF symbol table.

On disk, `9MB` saved (-27%) with the new container image:
```none
ghcr.io/score-spec/score-k8s                      0.6.4        1f7aada9625b   10 hours ago   24.2MB
ghcr.io/score-spec/score-k8s                      0.6.3        89d1a757c252   3 weeks ago    33.2MB
```