### PR TITLE
new custom `substituteValue` `sprig` func

### DIFF
--- a/internal/patching/patching.go
+++ b/internal/patching/patching.go
@@ -137,8 +137,8 @@ func PatchServices(state *project.State, manifests []map[string]interface{}, raw
 	return output, nil
 }
 
-// FIXME
 func SubstituteValue(workloadName string, value string) string {
+	// Retrieve context
 	sd, ok, err := project.LoadStateDirectory(".")
 	if err != nil || !ok {
 		return "failed to load state directory"
@@ -147,9 +147,12 @@ func SubstituteValue(workloadName string, value string) string {
 	resOutputs, err := state.GetResourceOutputForWorkload(workloadName)
 	workloadMetadata := state.Workloads[workloadName].Spec.Metadata
 	substitutionFunction := framework.BuildSubstitutionFunction(workloadMetadata, resOutputs)
+	
+	// Substitute placeholders if used in value
 	resolvedValue, err := framework.SubstituteString(value, substitutionFunction)
 	if err != nil {
-		return "failed to substitute placeholders"
+		return "failed to substitute placeholders with:" + value
 	}
+
 	return resolvedValue
 }


### PR DESCRIPTION
Add a new custom `substituteValue` `sprig` func that can be used in the patch templates.

This is important and actually mandatory when using `score-k8s` on top of Kubernetes CRs like Crossplane, Kratix, Kro, etc. in order to successfully inject and supply Score's placeholders: `${resources.*}`.

## Context

Given this Score file:
```yaml
apiVersion: score.dev/v1b1
metadata:
  name: workload
containers:
  container:
    image: test
    variables:
      STATIC_VALUE: "static value"
      DNS_HOST: "${resources.dns.host}"
      REDIS_PASSWORD: "${resources.redis.password}"
service:
  ports:
    http:
      port: 8080
      targetPort: 8080
resources:
  redis:
    type: redis
  dns:
    type: dns
  route:
    type: route
    params:
      host: ${resources.dns.host}
      path: /
      port: 8080
```
And this patch template:
```yaml
{{ range $i, $m := (reverse .Manifests) }}
{{ if ne $m.kind "Namespace" }}
{{ $i := sub (len $.Manifests) (add $i 1) }}
- op: delete
  path: {{ $i }}
{{ end }}
{{ end }}

{{ $namespace := .Namespace }}
{{ range $name, $spec := .Workloads }}
{{ $service := $spec.service }}
{{ $resources := $spec.resources }}
{{ $firstContainerName := index (keys $spec.containers) 0 }}
{{ $firstContainer := get $spec.containers $firstContainerName }}
- op: set
  path: -1
  value:
    apiVersion: kro.run/v1alpha1
    kind: Workload
    metadata:
      name: {{ $name }}
      {{ if ne $namespace "" }}
      namespace: {{ $namespace }}
      {{ end }}
    spec:
      image: {{ $firstContainer.image }}
      {{- if and $firstContainer.variables (gt (len $firstContainer.variables) 0) }}
      env:
        {{- range $variableName, $variableValue := $firstContainer.variables }}
        - name: {{ $variableName }}
          value: {{ substituteValue $name $variableValue }}
        {{ end }}
      {{ end }}
      {{- range $resourceName, $resource := $resources }}
      {{- if eq $resource.type "route" }}
      route:
        host: {{ substituteValue $name $resource.params.host }}
        path: {{ $resource.params.path }}
        port: {{ $resource.params.port }}
      {{ end }}
      {{ end }}
{{ end }}
```

Running this:
```bash
score-k8s init --patch-templates patch.templates.tpl
score-k8s generate score.yaml
```

## Before this PR

Before this PR, will generate this:
```yaml
---
apiVersion: kro.run/v1alpha1
kind: Workload
metadata:
    name: workload
spec:
    env:
        - name: DNS_HOST
          value: ${resources.dns.host}
        - name: REDIS_PASSWORD
          value: ${resources.redis.password}
        - name: STATIC_VALUE
          value: static value
    image: test
    route:
        host: ${resources.dns.host}
        path: /
        port: 8080
```

## After this PR

With this PR, will generate this instead:
```yaml
---
apiVersion: kro.run/v1alpha1
kind: Workload
metadata:
    name: workload
spec:
    env:
        - name: DNS_HOST
          value: dnsnvxnvx.localhost
        - name: REDIS_PASSWORD
          value: "\U0001F510\U0001F4ACredis-workload-1e22a976_password\U0001F4AC\U0001F510"
        - name: STATIC_VALUE
          value: static value
    image: test
    route:
        host: dnsnvxnvx.localhost
        path: /
        port: 8080
```

## Placeholder resolution in errors

If placeholder not successfully resolved, here is an example of the error message generated:
```none
Error: workload: workload: failed to convert: containers.container.variables: failed to convert: 'MYSQL_PASSWORD': failed to convert: failed to substitute placeholders: invalid ref 'resources.mysql.password': no known resource 'mysql'
```

## Parsing the secret refs

Here is an example of how one could handle and parse secret references returned by this sprig function:

Updating the patch template with this:
```yaml
...
        - name: {{ $variableName }}
          {{ $value := substituteValue $name $variableValue }}
          {{- if and (hasPrefix "\U0001F510\U0001F4AC" $value) (hasSuffix "\U0001F4AC\U0001F510" $value) }}
          {{ $trimmedValue := $value | trimPrefix "\U0001F510\U0001F4AC" | trimSuffix "\U0001F4AC\U0001F510" }}
          valueFrom:
            secretKeyRef:
              name: {{ index ( $trimmedValue | splitList "_" ) 0 }}
              key: {{ index ( $trimmedValue | splitList "_" ) 1 }}
          {{- else }}
          value: {{ $value }}
          {{ end }}
...
```

This will generate this:
```yaml
...
        - name: DNS_HOST
          value: dnsnvxnvx.localhost
        - name: REDIS_PASSWORD
          valueFrom:
            secretKeyRef:
                key: password
                name: redis-workload-1e22a976
        - name: STATIC_VALUE
          value: static value
...
```

## Notes

- Unit tests in CI are failing because of this unrelated issue: https://github.com/score-spec/score-k8s/issues/221, it won't be fixed here as part of the scope of this current PR.
- I'll create a future PR to implement unit tests associated to this, not adding them as part of this one. I'll do that after unit tests failure described above is fixed.