### PR TITLE
Add WorkloadMetadata field to provisioners for custom metadata access

### DIFF
--- a/internal/provisioners/core.go
+++ b/internal/provisioners/core.go
@@ -48,6 +48,9 @@ type Input struct {
 
 	// SourceWorkload is the name of the workload that first defined this resource or carries the params definition.
 	SourceWorkload string `json:"source_workload"`
+	// WorkloadMetadata contains the metadata from the source workload, allowing provisioners to access workload-level
+	// custom metadata fields in addition to standard fields.
+	WorkloadMetadata map[string]interface{} `json:"workload_metadata"`
 	// WorkloadServices is a map from workload name to the network NetworkService of another workload which defines
 	// the hostname and the set of ports it exposes.
 	WorkloadServices map[string]NetworkService `json:"workload_services"`
@@ -257,7 +260,7 @@ func ProvisionResources(ctx context.Context, state *project.State, provisioners 
 		}
 
 		var params map[string]interface{}
-		if resState.Params != nil && len(resState.Params) > 0 {
+		if len(resState.Params) > 0 {
 			resOutputs, err := out.GetResourceOutputForWorkload(resState.SourceWorkload)
 			if err != nil {
 				return nil, fmt.Errorf("failed to find resource params for resource '%s': %w", resUid, err)
@@ -280,6 +283,7 @@ func ProvisionResources(ctx context.Context, state *project.State, provisioners 
 			ResourceMetadata: resState.Metadata,
 			ResourceState:    resState.State,
 			SourceWorkload:   resState.SourceWorkload,
+			WorkloadMetadata: out.Workloads[resState.SourceWorkload].Spec.Metadata,
 			WorkloadServices: workloadServices,
 			SharedState:      out.SharedState,
 			Namespace:        namespace,

--- a/internal/provisioners/templateprov/template.go
+++ b/internal/provisioners/templateprov/template.go
@@ -182,6 +182,7 @@ type Data struct {
 	Shared map[string]interface{}
 
 	SourceWorkload   string
+	WorkloadMetadata map[string]interface{}
 	WorkloadServices map[string]provisioners.NetworkService
 	Namespace        string
 }
@@ -201,6 +202,7 @@ func (p *Provisioner) Provision(ctx context.Context, input *provisioners.Input) 
 		State:            input.ResourceState,
 		Shared:           input.SharedState,
 		SourceWorkload:   input.SourceWorkload,
+		WorkloadMetadata: input.WorkloadMetadata,
 		WorkloadServices: input.WorkloadServices,
 		Namespace:        input.Namespace,
 	}

--- a/internal/provisioners/templateprov/template_test.go
+++ b/internal/provisioners/templateprov/template_test.go
@@ -65,6 +65,7 @@ c: {{ .Shared.c }}
 		ResourceId:       resUid.Id(),
 		ResourceParams:   map[string]interface{}{"pk": "pv"},
 		ResourceMetadata: map[string]interface{}{"mk": "mv"},
+		WorkloadMetadata: map[string]interface{}{"name": "w", "customField": "customValue"},
 		ResourceState:    map[string]interface{}{"sk": "sv"},
 		SharedState:      map[string]interface{}{"ssk": "ssv"},
 	})


### PR DESCRIPTION
fixes #231 

#### Description
This PR adds a new `WorkloadMetadata` field to the provisioner `Input` struct and template `Data` struct, enabling provisioners to access workload-level metadata including custom fields defined in the Score specification's metadata section.

The changes include:
- Added `WorkloadMetadata map[string]interface{}` field to `Input` struct in `core.go`
- Added `WorkloadMetadata map[string]interface{}` field to template `Data` struct in `template.go`
- Populated `WorkloadMetadata` during resource provisioning from `workload.Spec.Metadata`
- Updated unit tests to verify workload metadata is correctly passed to provisioners
- Fixed a linter warning by removing redundant nil check before `len()` on map

#### What does this PR do?
This change fixes an issue where custom metadata fields defined at the workload level in `score.yaml` were not accessible in provisioner templates. 

**Problem**: Previously, only resource-level metadata was available via `.Metadata`, but users often define custom metadata fields (like `environmentPrefix`, `customField`, etc.) in the workload's metadata section. These fields were inaccessible to provisioners, forcing users to use workarounds like patch templates.

**Solution**: By adding `WorkloadMetadata` to the provisioner input, templates can now access both:
- `.Metadata` - resource-specific metadata
- `.WorkloadMetadata` - workload-level metadata including custom fields

This aligns with the Score specification's intent that metadata fields should be accessible throughout the provisioning process.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.