### PR TITLE
feat: use GetFiles to support importing provisioners from a local directory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/pkg/errors v0.9.1
-	github.com/score-spec/score-go v1.13.0
+	github.com/score-spec/score-go v1.15.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
-github.com/score-spec/score-go v1.13.0 h1:m4Df2U775DaEIdmfeYXULK9iS6Cb8eSXka9QD9udJcA=
-github.com/score-spec/score-go v1.13.0/go.mod h1:3abE79XO6CEiAzZNzfnHQIm18TWrefL0ihmObCvRWO8=
+github.com/score-spec/score-go v1.15.0 h1:P8b3CfUaoR885BSvU6FhV/2/Gz7BMQqYewMRkD0O19c=
+github.com/score-spec/score-go v1.15.0/go.mod h1:3abE79XO6CEiAzZNzfnHQIm18TWrefL0ihmObCvRWO8=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -208,12 +208,18 @@ URI Retrieval:
 
 		if v, _ := cmd.Flags().GetStringArray(initCmdProvisionerFlag); len(v) > 0 {
 			for i, vi := range v {
-				data, err := uriget.GetFile(cmd.Context(), vi)
+				files, err := uriget.GetFiles(cmd.Context(), vi)
 				if err != nil {
 					return fmt.Errorf("failed to load provisioner %d: %w", i+1, err)
 				}
-				if err := loader.SaveProvisionerToDirectory(sd.Path, vi, data); err != nil {
-					return fmt.Errorf("failed to save provisioner %d: %w", i+1, err)
+				for _, f := range files {
+					saveFilename := f.URI
+					if saveFilename == "-" {
+						saveFilename = "from-stdin.provisioners.yaml"
+					}
+					if err := loader.SaveProvisionerToDirectory(sd.Path, saveFilename, f.Content); err != nil {
+						return fmt.Errorf("failed to save provisioner from %s: %w", f.URI, err)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
#### Description

Port of score-spec/score-compose#465 to score-k8s. Replaces uriget.GetFile with uriget.GetFiles for the --provisioners flag in the init command, and bumps score-go to v1.15.0.

When a local directory path is passed, all provisioner files in the directory are imported individually, sorted by name. Single file paths, remote URIs, and stdin continue to work as before.

Depends on: score-spec/score-go#180

#### What does this PR do?

Relates to score-spec/score-go#177

Enables users to pass a local directory to --provisioners during score-k8s init, importing all provisioner files from that directory in a single command. Previously, each file had to be specified individually.

**Before:**
```
score-k8s init \
  --provisioners ./provisioners/10-ingress-route.provisioners.yaml \
  --provisioners ./provisioners/10-shared-gateway-httproute.provisioners.yaml
```

**After:**
`score-k8s init --provisioners ./provisioners/`


#### Testing Evidence

**Scenario 1: Single file**
```
$ score-k8s init \
  --no-sample \
  --provisioners ../community-provisioners/redis/score-k8s/10-redis-helm-template.provisioners.yaml

INFO: Writing new state directory
INFO: Writing new state directory
INFO: Created default provisioners file
INFO: Initial Score file does not exist - and sample generation is disabled
INFO: Read 990 bytes from ../community-provisioners/redis/score-k8s/10-redis-helm-template.provisioners.yaml
INFO: Wrote provisioner from '../community-provisioners/redis/score-k8s/10-redis-helm-template.provisioners.yaml' to .score-k8s/Z1mKT6ncYh8.HTF4GwRLQgYYIbFI4Iel7g.provisioners.yaml
INFO: Read more about the Score specification at https://docs.score.dev/docs/

$ ls .score-k8s/*.provisioners.yaml
.score-k8s/Z1mKT6ncYh8.HTF4GwRLQgYYIbFI4Iel7g.provisioners.yaml
.score-k8s/zz-default.provisioners.yaml
```


**Scenario 2: Directory (imports all 4 files)**
```
$ score-k8s init \
  --no-sample \
  --provisioners ../community-provisioners/route/score-k8s/

INFO: Writing new state directory
INFO: Writing new state directory
INFO: Created default provisioners file
INFO: Initial Score file does not exist - and sample generation is disabled
INFO: Read 1521 bytes from ../community-provisioners/route/score-k8s/10-ingress-route.provisioners.yaml
INFO: Read 2318 bytes from ../community-provisioners/route/score-k8s/10-ingress-with-netpol-route.provisioners.yaml
INFO: Read 2607 bytes from ../community-provisioners/route/score-k8s/10-shared-gateway-httproute-with-netpol.provisioners.yaml
INFO: Read 1980 bytes from ../community-provisioners/route/score-k8s/10-shared-gateway-httproute.provisioners.yaml
INFO: Wrote provisioner from '../community-provisioners/route/score-k8s/10-ingress-route.provisioners.yaml' to .score-k8s/Z1mKTtRGsdc.T0BIScMxx3bifunHSU8SiA.provisioners.yaml
INFO: Wrote provisioner from '../community-provisioners/route/score-k8s/10-ingress-with-netpol-route.provisioners.yaml' to .score-k8s/Z1mKTtQ89ac._0lwL7pOLQgR6HJuD84cyw.provisioners.yaml
INFO: Wrote provisioner from '../community-provisioners/route/score-k8s/10-shared-gateway-httproute-with-netpol.provisioners.yaml' to .score-k8s/Z1mKTtQzwi8.WcYWaEZQ6eLfS2kWgKS6nw.provisioners.yaml
INFO: Wrote provisioner from '../community-provisioners/route/score-k8s/10-shared-gateway-httproute.provisioners.yaml' to .score-k8s/Z1mKTtQr7kc.llG8by0AzeuZ_A_FU-mkWA.provisioners.yaml
INFO: Read more about the Score specification at https://docs.score.dev/docs/

$ ls .score-k8s/*.provisioners.yaml
.score-k8s/Z1mKTtQ89ac._0lwL7pOLQgR6HJuD84cyw.provisioners.yaml
.score-k8s/Z1mKTtQr7kc.llG8by0AzeuZ_A_FU-mkWA.provisioners.yaml
.score-k8s/Z1mKTtQzwi8.WcYWaEZQ6eLfS2kWgKS6nw.provisioners.yaml
.score-k8s/Z1mKTtRGsdc.T0BIScMxx3bifunHSU8SiA.provisioners.yaml
.score-k8s/zz-default.provisioners.yaml
```


**Scenario 3: Stdin**
```
$ cat ../community-provisioners/redis/score-k8s/10-redis-helm-template.provisioners.yaml | \
  score-k8s init \
  --no-sample \
  --provisioners -

INFO: Writing new state directory
INFO: Writing new state directory
INFO: Created default provisioners file
INFO: Initial Score file does not exist - and sample generation is disabled
INFO: Wrote provisioner from 'from-stdin.provisioners.yaml' to .score-k8s/Z1mKTexBWxc.AT4RADwrCq4ehgoH5VNIdg.provisioners.yaml
INFO: Read more about the Score specification at https://docs.score.dev/docs/

$ ls .score-k8s/*.provisioners.yaml
.score-k8s/Z1mKTexBWxc.AT4RADwrCq4ehgoH5VNIdg.provisioners.yaml
.score-k8s/zz-default.provisioners.yaml
```


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.