### PR TITLE
fix: sort map keys for deterministic manifest output

### DIFF
--- a/internal/convert/workloads.go
+++ b/internal/convert/workloads.go
@@ -16,6 +16,7 @@ package convert
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 
@@ -110,7 +111,8 @@ func ConvertWorkload(state *project.State, workloadName string) ([]machineryMeta
 			}
 			return sf(ref)
 		}
-		for target, volume := range container.Volumes {
+		for _, target := range slices.Sorted(maps.Keys(container.Volumes)) {
+			volume := container.Volumes[target]
 			if mount, vol, claim, err := convertContainerVolume(target, volume, state.Resources, volSubstitutionFunction); err != nil {
 				return nil, errors.Wrapf(err, "containers.%s.volumes.%s: failed to convert", containerName, target)
 			} else {
@@ -126,7 +128,8 @@ func ConvertWorkload(state *project.State, workloadName string) ([]machineryMeta
 			}
 		}
 
-		for target, f := range container.Files {
+		for _, target := range slices.Sorted(maps.Keys(container.Files)) {
+			f := container.Files[target]
 			if mount, cfg, vol, err := convertContainerFile(target, f, fmt.Sprintf("%s-%s-", workloadName, containerName), state.Workloads[workloadName].File, sf); err != nil {
 				return nil, errors.Wrapf(err, "containers.%s.files.%s: failed to convert", containerName, target)
 			} else {

--- a/internal/convert/workloads_test.go
+++ b/internal/convert/workloads_test.go
@@ -135,17 +135,17 @@ func TestMassive(t *testing.T) {
 	}
 	assert.Equal(t, `apiVersion: v1
 binaryData:
-  file: bXktY29udGVudCBleGFtcGxl
-kind: ConfigMap
-metadata:
-  name: example-c1-file-7a1ae64977
----
-apiVersion: v1
-binaryData:
   file: aGVsbG8gJHttZXRhZGF0YS5uYW1lfSB3b3JsZA==
 kind: ConfigMap
 metadata:
   name: example-c1-file-d0e9aff012
+---
+apiVersion: v1
+binaryData:
+  file: bXktY29udGVudCBleGFtcGxl
+kind: ConfigMap
+metadata:
+  name: example-c1-file-7a1ae64977
 ---
 apiVersion: v1
 kind: Service
@@ -245,13 +245,13 @@ spec:
           - configMap:
               items:
               - key: file
-                path: root.md
-              name: example-c1-file-7a1ae64977
+                path: binary
+              name: example-c1-file-d0e9aff012
           - configMap:
               items:
               - key: file
-                path: binary
-              name: example-c1-file-d0e9aff012
+                path: root.md
+              name: example-c1-file-7a1ae64977
 status: {}
 ---
 `, out.String())


### PR DESCRIPTION
#### Description

Iteration over container.Files and container.Volumes maps in ConvertWorkload used non-deterministic Go map ordering, causing the generated ConfigMap manifests and projected volume sources to appear in random order across runs.

Per the [Go language specification](https://go.dev/ref/spec#For_range):

> The iteration order over maps is not specified and is not guaranteed to be the same from one iteration to the next.

This fix sorts the map keys before iterating, using slices.Sorted(maps.Keys(...)), matching the pattern already used for containerNames in the same function. The test expected output is updated to reflect the deterministic sorted order.

#### What does this PR do?

Fixes flaky TestMassive test caused by non-deterministic Go map iteration order over container.Files and container.Volumes.

Also ensures score-k8s generate produces reproducible manifest output, making diffs clean when regenerating without actual changes.

Fixes https://github.com/score-spec/score-k8s/issues/221

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.