### PR TITLE
feat: use GetFiles for --patch-templates to support local directories

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -103,13 +103,16 @@ URI Retrieval:
 		var templates []string
 		for _, u := range initCmdPatchingFiles {
 			slog.Info(fmt.Sprintf("Fetching patch template from %s", u))
-			content, err := uriget.GetFile(cmd.Context(), u)
+			files, err := uriget.GetFiles(cmd.Context(), u)
 			if err != nil {
 				return fmt.Errorf("error fetching patch template from %s: %w", u, err)
-			} else if err = patching.ValidatePatchTemplate(string(content)); err != nil {
-				return fmt.Errorf("error parsing patch template from %s: %w", u, err)
 			}
-			templates = append(templates, string(content))
+			for _, f := range files {
+				if err = patching.ValidatePatchTemplate(string(f.Content)); err != nil {
+					return fmt.Errorf("error parsing patch template from %s: %w", f.URI, err)
+				}
+				templates = append(templates, string(f.Content))
+			}
 		}
 
 		sd, ok, err := project.LoadStateDirectory(".")


### PR DESCRIPTION
#### Description

The --patch-templates flag in score-k8s init used uriget.GetFile which only supports single file URIs. This change replaces it with uriget.GetFiles, which additionally supports passing a local directory path to load all patch template files from it at once.

This mirrors the same change already done for the --provisioners flag in https://github.com/score-spec/score-k8s/pull/292.

Related issue: https://github.com/score-spec/score-go/issues/177

#### What does this PR do?

Enables --patch-templates to accept a local directory path, loading all files within it as patch templates. Previously, only individual file paths and remote URIs were supported.

All existing behavior (single file, remote URI, stdin) remains unchanged.

#### Testing evidence

**Single file:**
```
./score-k8s init --no-sample --patch-templates ../community-patchers/score-k8s/unprivileged.tpl
INFO: Fetching patch template from ../community-patchers/score-k8s/unprivileged.tpl
INFO: Read 680 bytes from ../community-patchers/score-k8s/unprivileged.tpl
INFO: Writing new state directory
INFO: Writing new state directory
INFO: Created default provisioners file
INFO: Skipping creation of initial Score file since it already exists
INFO: Read more about the Score specification at https://docs.score.dev/docs/
```
state.yaml
```
yq '.patching_templates' .score-k8s/state.yaml
- |
  {{ range $i, $m := .Manifests }}
  {{ if eq $m.kind "Deployment" }}
  - op: set
    path: {{ $i }}.spec.template.spec.automountServiceAccountToken
    value: false
  - op: set
    path: {{ $i }}.spec.template.spec.securityContext
    value:
      fsGroup: 65532
      runAsGroup: 65532
      runAsNonRoot: true
      runAsUser: 65532
      seccompProfile:
        type: "RuntimeDefault"
  {{ range $cname, $_ := $m.spec.template.spec.containers }}
  - op: set
    path: {{ $i }}.spec.template.spec.containers.{{ $cname }}.securityContext
    value:
      allowPrivilegeEscalation: false
      privileged: false
      readOnlyRootFilesystem: true
      capabilities:
        drop:
          - ALL
  {{ end }}
  {{ end }}
  {{ end }}
```

**Directory:**
```
./score-k8s init --no-sample --patch-templates ../community-patchers/score-k8s/
INFO: Fetching patch template from ../community-patchers/score-k8s/
INFO: Read 3856 bytes from ../community-patchers/score-k8s/backstage-catalog-entities.tpl
INFO: Read 450 bytes from ../community-patchers/score-k8s/delete-default-manifests.tpl
INFO: Read 743 bytes from ../community-patchers/score-k8s/knative-service.tpl
INFO: Read 184 bytes from ../community-patchers/score-k8s/namespace-pss-restricted.tpl
INFO: Read 439 bytes from ../community-patchers/score-k8s/namespace-with-allow-ingress-within-namespace-netpol.tpl
INFO: Read 289 bytes from ../community-patchers/score-k8s/namespace-with-deny-all-netpol.tpl
INFO: Read 849 bytes from ../community-patchers/score-k8s/service-account-admin.tpl
INFO: Read 419 bytes from ../community-patchers/score-k8s/service-account.tpl
INFO: Read 298 bytes from ../community-patchers/score-k8s/statefulset.tpl
INFO: Read 680 bytes from ../community-patchers/score-k8s/unprivileged.tpl
INFO: Writing new state directory
INFO: Writing new state directory
INFO: Created default provisioners file
INFO: Skipping creation of initial Score file since it already exists
INFO: Read more about the Score specification at https://docs.score.dev/docs/
```
state.yaml
```
yq '.patching_templates' .score-k8s/state.yaml
- |-
  {{/* Adapt this user value as per your own context */}}
  {{ $user := "guest" }}

  {{ $namespace := .Namespace }}
  {{ $componentAndResourcePrefix := ne $namespace "" | ternary (print $namespace "-") "" }}

  {{/* remove the default generated manifests */}}
  {{ range $i, $m := (reverse .Manifests) }}
  {{ $i := sub (len $.Manifests) (add $i 1) }}
  - op: delete
    path: {{ $i }}
  {{ end }}

  {{/* generate System if --generate-namespace is supplied */}}
  {{ range $i, $m := .Manifests }}
  {{ if eq $m.kind "Namespace" }}
  - op: set
    path: -1
    value:
      apiVersion: backstage.io/v1alpha1
      kind: System
      metadata:
        name: {{ $namespace }}
        description: {{ $namespace }}
        annotations:
          github.com/project-slug: $GITHUB_REPO
        links:
          - url: https://github.com/$GITHUB_REPO
            title: Repository
            icon: github
      spec:
        owner: user:{{ $user }}
  {{ end }}
  {{ end }}

  {{/* generate a Component per Workload */}}
  {{ range $name, $spec := .Workloads }}
  - op: set
    path: -1
    value:
      apiVersion: backstage.io/v1alpha1
 .....
  {{ end }}
```

**Stdin:**
```
cat ../community-patchers/score-k8s/unprivileged.tpl | ./score-k8s init --no-sample --patch-templates -
INFO: Fetching patch template from -
INFO: Writing new state directory
INFO: Writing new state directory
INFO: Created default provisioners file
INFO: Skipping creation of initial Score file since it already exists
INFO: Read more about the Score specification at https://docs.score.dev/docs/
```
state.yaml
```
yq '.patching_templates' .score-k8s/state.yaml
- |
  {{ range $i, $m := .Manifests }}
  {{ if eq $m.kind "Deployment" }}
  - op: set
    path: {{ $i }}.spec.template.spec.automountServiceAccountToken
    value: false
  - op: set
    path: {{ $i }}.spec.template.spec.securityContext
    value:
      fsGroup: 65532
      runAsGroup: 65532
      runAsNonRoot: true
      runAsUser: 65532
      seccompProfile:
        type: "RuntimeDefault"
  {{ range $cname, $_ := $m.spec.template.spec.containers }}
  - op: set
    path: {{ $i }}.spec.template.spec.containers.{{ $cname }}.securityContext
    value:
      allowPrivilegeEscalation: false
      privileged: false
      readOnlyRootFilesystem: true
      capabilities:
        drop:
          - ALL
  {{ end }}
  {{ end }}
  {{ end }}
```

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.