### PR TITLE
init: update the default sample Score file generated

### DIFF
--- a/internal/command/generate_test.go
+++ b/internal/command/generate_test.go
@@ -199,13 +199,13 @@ func TestInitAndGenerate_with_sample(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "", stdout)
 
-	// write overrides file
+	// write overrides file adding an extra resource
 	assert.NoError(t, os.WriteFile(filepath.Join(td, "overrides.yaml"), []byte(`{"resources": {"foo": {"type": "example-provisioner-resource"}}}`), 0644))
-	// generate
+	// generate using the default sample score file
 	stdout, _, err = executeAndResetCommand(context.Background(), rootCmd, []string{
 		"generate", "-o", "manifests.yaml",
 		"--overrides-file", "overrides.yaml",
-		"--override-property", "containers.main.variables.THING=${resources.foo.plaintext}",
+		"--override-property", "containers.hello-world.variables.THING=${resources.foo.plaintext}",
 		"--", "score.yaml",
 	})
 	require.NoError(t, err)
@@ -216,13 +216,14 @@ func TestInitAndGenerate_with_sample(t *testing.T) {
 	assert.Contains(t, string(raw), "\nkind: Service\n")
 	assert.Contains(t, string(raw), "\nkind: Deployment\n")
 
-	// check that state was persisted
+	// check that state was persisted with the new sample structure
 	sd, ok, err := project.LoadStateDirectory(td)
 	assert.NoError(t, err)
 	assert.True(t, ok)
-	assert.Equal(t, "score.yaml", *sd.State.Workloads["example"].File)
+	assert.Equal(t, "score.yaml", *sd.State.Workloads["hello-world"].File)
 	assert.Len(t, sd.State.Workloads, 1)
-	assert.Len(t, sd.State.Resources, 1)
+	// 3 resources from the sample (db, dns, route) + 1 from the overrides file (foo)
+	assert.Len(t, sd.State.Resources, 4)
 }
 
 func TestInitAndGenerate_with_image_override(t *testing.T) {

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -22,10 +22,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/score-spec/score-go/framework"
-	scoretypes "github.com/score-spec/score-go/types"
 	"github.com/score-spec/score-go/uriget"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 
 	"github.com/score-spec/score-k8s/internal/patching"
 	"github.com/score-spec/score-k8s/internal/project"
@@ -39,6 +37,46 @@ const (
 	initCmdProvisionerFlag           = "provisioners"
 	initCmdPatchTemplateFlag         = "patch-templates"
 	initCmdNoDefaultProvisionersFlag = "no-default-provisioners"
+
+	DefaultScoreFileContent = `# Score provides a developer-centric and platform-agnostic
+# Workload specification to improve developer productivity and experience.
+# Score eliminates configuration management between local and remote environments.
+#
+# Get started with Score: https://docs.score.dev/docs/get-started/.
+---
+apiVersion: score.dev/v1b1
+metadata:
+  name: hello-world
+  annotations:
+    tags: "nodejs,http,website,javascript,postgres"
+containers:
+  hello-world:
+    image: scorespec/sample-score-app:latest
+    variables:
+      PORT: "3000"
+      MESSAGE: "Hello, World!"
+      DB_DATABASE: ${resources.db.name}
+      DB_USER: ${resources.db.username}
+      DB_PASSWORD: ${resources.db.password}
+      DB_HOST: ${resources.db.host}
+      DB_PORT: ${resources.db.port}
+resources:
+  db:
+    type: postgres
+  dns:
+    type: dns
+  route:
+    type: route
+    params:
+      host: ${resources.dns.host}
+      path: /
+      port: 8080
+service:
+  ports:
+    www:
+      port: 8080
+      targetPort: 3000
+`
 )
 
 var initCmd = &cobra.Command{
@@ -177,33 +215,10 @@ URI Retrieval:
 			if v, _ := cmd.Flags().GetBool(initCmdFileNoSampleFlag); v {
 				slog.Info("Initial Score file does not exist - and sample generation is disabled", "file", initCmdScoreFile)
 			} else {
-				workload := &scoretypes.Workload{
-					ApiVersion: "score.dev/v1b1",
-					Metadata: map[string]interface{}{
-						"name": "example",
-					},
-					Containers: map[string]scoretypes.Container{
-						"main": {
-							Image: "stefanprodan/podinfo",
-						},
-					},
-					Service: &scoretypes.WorkloadService{
-						Ports: map[string]scoretypes.ServicePort{
-							"web": {Port: 8080},
-						},
-					},
+				if err := os.WriteFile(initCmdScoreFile, []byte(DefaultScoreFileContent), 0755); err != nil {
+					return errors.Wrap(err, "failed to write Score file")
 				}
-				if f, err := os.OpenFile(initCmdScoreFile, os.O_CREATE|os.O_WRONLY, 0755); err != nil {
-					return errors.Wrap(err, "failed to open empty Score file")
-				} else {
-					defer f.Close()
-					enc := yaml.NewEncoder(f)
-					enc.SetIndent(2)
-					if err := enc.Encode(workload); err != nil {
-						return errors.Wrap(err, "failed to write Score file")
-					}
-					slog.Info("Created initial Score file", "file", initCmdScoreFile)
-				}
+				slog.Info("Created initial Score file", "file", initCmdScoreFile)
 			}
 		} else {
 			slog.Info("Skipping creation of initial Score file since it already exists", "file", initCmdScoreFile)

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -56,7 +56,12 @@ func TestInitNominal(t *testing.T) {
 	if assert.True(t, ok) {
 		assert.Equal(t, project.DefaultRelativeStateDirectory, sd.Path)
 		assert.Len(t, sd.State.Workloads, 1)
-		assert.Equal(t, map[framework.ResourceUid]framework.ScoreResourceState[project.ResourceExtras]{}, sd.State.Resources)
+		assert.Contains(t, sd.State.Workloads, "hello-world")
+		// Resources use randomized service names in compose output, so check state instead.
+		assert.Len(t, sd.State.Resources, 3)
+		assert.Contains(t, sd.State.Resources, framework.ResourceUid("postgres.default#hello-world.db"))
+		assert.Contains(t, sd.State.Resources, framework.ResourceUid("dns.default#hello-world.dns"))
+		assert.Contains(t, sd.State.Resources, framework.ResourceUid("route.default#hello-world.route"))
 		assert.Equal(t, map[string]interface{}{}, sd.State.SharedState)
 	}
 }


### PR DESCRIPTION
#### Description
The default `score.yaml` generated by `score-k8s init` used a basic example with `stefanprodan/podinfo` that didn't really demonstrate what Score is capable of. This PR replaces it with the same meaningful sample used in score-compose, for consistency across implementations.

#### What does this PR do?
This is a follow-up to score-spec/score-compose#476 as requested by @mathieu-benoit.

Updates the sample generated by `score-k8s init` to use:
- `scorespec/sample-score-app:latest` instead of `stefanprodan/podinfo`
- A **postgres** database resource with environment variable injection (`DB_HOST`, `DB_PORT`, `DB_DATABASE`, etc.)
- A **dns** resource and a **route** resource for HTTP routing
- Header comments pointing to https://docs.score.dev/docs/get-started/

Also switched from struct-based YAML generation to a `DefaultScoreFileContent` raw string constant (same approach as score-compose), which is simpler and supports comments.

Updated `TestInitNominal` and `TestInitAndGenerate_with_sample` to reflect the new sample structure.

#### Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [x] My change requires a change to the documentation.
- [x] I've signed off with an email address that matches the commit author.
