### PR TITLE
fix: dedupe shared volumes at pod level (#363)

### DIFF
--- a/internal/convert/container_volumes.go
+++ b/internal/convert/container_volumes.go
@@ -16,10 +16,10 @@ package convert
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"slices"
-	"crypto/sha256"
 
 	"github.com/pkg/errors"
 	"github.com/score-spec/score-go/framework"
@@ -188,4 +188,39 @@ func collapseVolumeMounts(volumes []coreV1.Volume, mounts []coreV1.VolumeMount) 
 	}
 
 	return outputVols, outputMounts, nil
+}
+
+// dedupeVolumesByName keeps the first volume for each name so a Score volume
+// shared across containers appears once in pod.spec.volumes.
+func dedupeVolumesByName(volumes []coreV1.Volume) []coreV1.Volume {
+	if len(volumes) < 2 {
+		return volumes
+	}
+	seen := make(map[string]struct{}, len(volumes))
+	out := make([]coreV1.Volume, 0, len(volumes))
+	for _, vol := range volumes {
+		if _, ok := seen[vol.Name]; ok {
+			continue
+		}
+		seen[vol.Name] = struct{}{}
+		out = append(out, vol)
+	}
+	return out
+}
+
+// dedupeVolumeClaimTemplatesByName keeps the first PVC template for each name.
+func dedupeVolumeClaimTemplatesByName(claims []coreV1.PersistentVolumeClaim) []coreV1.PersistentVolumeClaim {
+	if len(claims) < 2 {
+		return claims
+	}
+	seen := make(map[string]struct{}, len(claims))
+	out := make([]coreV1.PersistentVolumeClaim, 0, len(claims))
+	for _, claim := range claims {
+		if _, ok := seen[claim.Name]; ok {
+			continue
+		}
+		seen[claim.Name] = struct{}{}
+		out = append(out, claim)
+	}
+	return out
 }

--- a/internal/convert/container_volumes_test.go
+++ b/internal/convert/container_volumes_test.go
@@ -218,3 +218,29 @@ func Test_collapseVolumeMounts_nominal(t *testing.T) {
 		{Name: "v4", MountPath: "/c"},
 	}, mounts)
 }
+
+func Test_dedupeVolumesByName(t *testing.T) {
+	vols := []coreV1.Volume{
+		{Name: "vol-a", VolumeSource: coreV1.VolumeSource{EmptyDir: &coreV1.EmptyDirVolumeSource{}}},
+		{Name: "vol-b", VolumeSource: coreV1.VolumeSource{EmptyDir: &coreV1.EmptyDirVolumeSource{}}},
+		{Name: "vol-a", VolumeSource: coreV1.VolumeSource{EmptyDir: &coreV1.EmptyDirVolumeSource{}}},
+	}
+	got := dedupeVolumesByName(vols)
+	assert.Equal(t, []coreV1.Volume{
+		{Name: "vol-a", VolumeSource: coreV1.VolumeSource{EmptyDir: &coreV1.EmptyDirVolumeSource{}}},
+		{Name: "vol-b", VolumeSource: coreV1.VolumeSource{EmptyDir: &coreV1.EmptyDirVolumeSource{}}},
+	}, got)
+}
+
+func Test_dedupeVolumeClaimTemplatesByName(t *testing.T) {
+	claims := []coreV1.PersistentVolumeClaim{
+		{ObjectMeta: v1.ObjectMeta{Name: "vol-a"}},
+		{ObjectMeta: v1.ObjectMeta{Name: "vol-b"}},
+		{ObjectMeta: v1.ObjectMeta{Name: "vol-a"}},
+	}
+	got := dedupeVolumeClaimTemplatesByName(claims)
+	assert.Equal(t, []coreV1.PersistentVolumeClaim{
+		{ObjectMeta: v1.ObjectMeta{Name: "vol-a"}},
+		{ObjectMeta: v1.ObjectMeta{Name: "vol-b"}},
+	}, got)
+}

--- a/internal/convert/workloads.go
+++ b/internal/convert/workloads.go
@@ -165,6 +165,12 @@ func ConvertWorkload(state *project.State, workloadName string) ([]machineryMeta
 		containers = append(containers, c)
 	}
 
+	// Pod-level volume names must be unique. The same Score volume resource can be
+	// mounted by multiple containers (e.g. init + main), which produces identical
+	// volume entries when accumulated per-container — keep the first occurrence.
+	volumes = dedupeVolumesByName(volumes)
+	volumeClaimTemplates = dedupeVolumeClaimTemplatesByName(volumeClaimTemplates)
+
 	// We want to apply the annotations from the workload onto the pod.
 	// See the doc of buildPodAnnotations for what gets included here.
 	podAnnotations := buildPodAnnotations(spec.Metadata)

--- a/internal/convert/workloads_test.go
+++ b/internal/convert/workloads_test.go
@@ -23,6 +23,7 @@ import (
 	scoretypes "github.com/score-spec/score-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/score-spec/score-k8s/internal"
@@ -255,4 +256,64 @@ spec:
 status: {}
 ---
 `, out.String())
+}
+
+func TestConvertWorkload_sharedVolumeAcrossContainers(t *testing.T) {
+	var err error
+	state := new(project.State)
+	state, err = state.WithWorkload(&scoretypes.Workload{
+		Metadata: map[string]interface{}{"name": "shared-vol"},
+		Containers: map[string]scoretypes.Container{
+			"main": {
+				Image:   "busybox",
+				Command: []string{"sh", "-c", "sleep 3600"},
+				Volumes: map[string]scoretypes.ContainerVolume{
+					"/data": {Source: "${resources.data}"},
+				},
+			},
+			"init": {
+				Image:   "busybox",
+				Command: []string{"sh", "-c", "echo hi > /data/f"},
+				Volumes: map[string]scoretypes.ContainerVolume{
+					"/data": {Source: "${resources.data}"},
+				},
+			},
+		},
+		Resources: map[string]scoretypes.Resource{
+			"data": {Type: "volume"},
+		},
+	}, nil, project.WorkloadExtras{InstanceSuffix: "-abcdef"})
+	require.NoError(t, err)
+	state.Resources = map[framework.ResourceUid]framework.ScoreResourceState[project.ResourceExtras]{
+		"volume.default#shared-vol.data": {
+			Type:  "volume",
+			Class: "default",
+			Id:    "",
+			Outputs: map[string]interface{}{
+				"source": map[string]interface{}{
+					"emptyDir": map[string]interface{}{},
+				},
+			},
+		},
+	}
+
+	manifests, err := ConvertWorkload(state, "shared-vol")
+	require.NoError(t, err)
+	require.Len(t, manifests, 1)
+
+	dep, ok := manifests[0].(*appsv1.Deployment)
+	require.True(t, ok, "expected Deployment")
+
+	vols := dep.Spec.Template.Spec.Volumes
+	require.Len(t, vols, 1, "shared volume must appear once at pod level")
+	assert.Equal(t, "vol-bd47413b5c", vols[0].Name)
+	assert.NotNil(t, vols[0].EmptyDir)
+
+	containers := dep.Spec.Template.Spec.Containers
+	require.Len(t, containers, 2)
+	for _, c := range containers {
+		require.Len(t, c.VolumeMounts, 1, "container %s should mount the shared volume", c.Name)
+		assert.Equal(t, vols[0].Name, c.VolumeMounts[0].Name)
+		assert.Equal(t, "/data", c.VolumeMounts[0].MountPath)
+	}
 }


### PR DESCRIPTION
## Summary
- Fixes #363: when multiple containers mount the same Score volume resource (e.g. init + main staging into `emptyDir`), `score-k8s generate` no longer emits duplicate entries in `pod.spec.volumes`.
- After per-container volume conversion, pod-level volumes and StatefulSet volume claim templates are deduplicated by name so a shared volume appears once while each container still mounts it.

## Test plan
- [x] `go test ./internal/convert/ -count=1`
- [x] `go test ./... -count=1`
- [x] New regression test mirrors the issue repro (init + main both mount `${resources.data}` at `/data`) and asserts a single pod volume with mounts on both containers
- [x] Unit tests for `dedupeVolumesByName` / `dedupeVolumeClaimTemplatesByName`