### PR TITLE
fix: collapse volumes shared across containers

### DIFF
--- a/internal/convert/workloads.go
+++ b/internal/convert/workloads.go
@@ -17,6 +17,7 @@ package convert
 import (
 	"fmt"
 	"maps"
+	"reflect"
 	"slices"
 	"strings"
 
@@ -149,7 +150,15 @@ func ConvertWorkload(state *project.State, workloadName string) ([]machineryMeta
 			return nil, errors.Wrapf(err, "containers.%s.volumes: failed to combine projected volumes", containerName)
 		}
 		c.VolumeMounts = containerVolumeMounts
-		volumes = append(volumes, containerVolumes...)
+		// collapseVolumeMounts only dedupes within a single container, but the pod-level
+		// volume list is shared across all containers. A volume referenced by more than one
+		// container (e.g. an init container staging files into an emptyDir the main container
+		// reads) must appear only once here, otherwise Kubernetes rejects the pod with a
+		// "Duplicate value" error on spec.template.spec.volumes.
+		volumes, err = appendPodVolumes(volumes, containerVolumes)
+		if err != nil {
+			return nil, errors.Wrapf(err, "containers.%s.volumes", containerName)
+		}
 
 		if container.LivenessProbe != nil {
 			if c.LivenessProbe, err = buildProbe(container.LivenessProbe); err != nil {
@@ -284,6 +293,24 @@ func ConvertWorkload(state *project.State, workloadName string) ([]machineryMeta
 	}
 
 	return manifests, nil
+}
+
+// appendPodVolumes adds the given container-level volumes to the pod-level volume list,
+// collapsing volumes that are shared across containers. Volume names are deterministic
+// (derived from the mount target or resource), so a volume mounted by multiple containers
+// yields the same name each time; it must be emitted only once. A name that maps to two
+// genuinely different volume definitions is a conflict and returns an error.
+func appendPodVolumes(volumes []coreV1.Volume, additions []coreV1.Volume) ([]coreV1.Volume, error) {
+	for _, add := range additions {
+		if i := slices.IndexFunc(volumes, func(v coreV1.Volume) bool { return v.Name == add.Name }); i >= 0 {
+			if !reflect.DeepEqual(volumes[i], add) {
+				return nil, errors.Errorf("volume '%s' is mounted by multiple containers with conflicting definitions", add.Name)
+			}
+			continue
+		}
+		volumes = append(volumes, add)
+	}
+	return volumes, nil
 }
 
 func WorkloadServiceName(workloadName string, specMetadata map[string]interface{}) string {

--- a/internal/convert/workloads_test.go
+++ b/internal/convert/workloads_test.go
@@ -23,6 +23,7 @@ import (
 	scoretypes "github.com/score-spec/score-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/score-spec/score-k8s/internal"
@@ -255,4 +256,66 @@ spec:
 status: {}
 ---
 `, out.String())
+}
+
+// TestSharedVolumeAcrossContainers reproduces https://github.com/score-spec/score-k8s/issues/363:
+// when two containers mount the same volume resource at the same path (e.g. an init container
+// staging files into an emptyDir that the main container reads), the pod-level volume list must
+// contain that volume only once, otherwise Kubernetes rejects the pod with a "Duplicate value" error.
+func TestSharedVolumeAcrossContainers(t *testing.T) {
+	state := new(project.State)
+	state, err := state.WithWorkload(&scoretypes.Workload{
+		Metadata: map[string]interface{}{"name": "example"},
+		Containers: map[string]scoretypes.Container{
+			"main": {
+				Image: "main-image",
+				Volumes: map[string]scoretypes.ContainerVolume{
+					"/data": {Source: "${resources.vol}"},
+				},
+			},
+			"init": {
+				Image: "init-image",
+				Volumes: map[string]scoretypes.ContainerVolume{
+					"/data": {Source: "${resources.vol}"},
+				},
+			},
+		},
+		Resources: map[string]scoretypes.Resource{
+			"vol": {Type: "vol", Class: internal.Ref("default")},
+		},
+	}, nil, project.WorkloadExtras{})
+	require.NoError(t, err)
+	state.Resources = map[framework.ResourceUid]framework.ScoreResourceState[project.ResourceExtras]{
+		"vol.default#example.vol": {
+			Type:  "vol",
+			Class: "default",
+			Outputs: map[string]interface{}{
+				"source": map[string]interface{}{"emptyDir": map[string]interface{}{}},
+			},
+		},
+	}
+
+	manifests, err := ConvertWorkload(state, "example")
+	require.NoError(t, err)
+
+	var deployment *v1.Deployment
+	for _, m := range manifests {
+		if d, ok := m.(*v1.Deployment); ok {
+			deployment = d
+		}
+	}
+	require.NotNil(t, deployment)
+
+	volumes := deployment.Spec.Template.Spec.Volumes
+	require.Len(t, volumes, 1, "shared volume must be collapsed into a single pod-level volume")
+
+	// Both containers must reference that single volume by name.
+	names := make([]string, 0, len(volumes))
+	for _, v := range volumes {
+		names = append(names, v.Name)
+	}
+	for _, c := range deployment.Spec.Template.Spec.Containers {
+		require.Len(t, c.VolumeMounts, 1)
+		assert.Contains(t, names, c.VolumeMounts[0].Name)
+	}
 }


### PR DESCRIPTION
#### Description

`score-k8s generate` emitted invalid manifests when two containers in a workload mounted the same volume resource. The shared volume was duplicated in `spec.template.spec.volumes`, and Kubernetes rejected the pod with a `Duplicate value` error on the volume name.

Volume names are deterministic (derived from the mount target), so a volume mounted by more than one container was emitted once per container. `collapseVolumeMounts` only deduplicated volumes *within* a single container, and the pod-level volume list was then accumulated container by container with no cross-container deduplication.

This change collapses identically-named volumes into a single pod-level entry when accumulating them across containers, and errors on a genuine name conflict (the same name mapping to two different volume definitions). A regression test reproduces the shared-`emptyDir` init-container pattern.

#### What does this PR do?

It fixes a common pattern where an init container stages files into an `emptyDir` that the main container reads: both containers reference the same volume resource, which previously produced a pod spec with a duplicated volume name that the API server refused to admit.

Fixes #363

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:

- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.
