### PR TITLE
fix: derive volume names from the volume source instead of the mount path (#367)

### DIFF
--- a/internal/convert/container_volumes.go
+++ b/internal/convert/container_volumes.go
@@ -36,18 +36,23 @@ func convertContainerVolume(
 	resources map[framework.ResourceUid]framework.ScoreResourceState[project.ResourceExtras],
 	substitutionFunc func(string) (string, error),
 ) (coreV1.VolumeMount, *coreV1.Volume, *coreV1.PersistentVolumeClaim, error) {
-	targetHash := sha256.Sum256([]byte(target))
-	volName := fmt.Sprintf("vol-%x", targetHash[:5])
+	resolvedVolumeSource, err := framework.SubstituteString(volume.Source, substitutionFunc)
+	if err != nil {
+		return coreV1.VolumeMount{}, nil, nil, errors.Wrap(err, "source: failed to resolve placeholder")
+	}
+
+	// The volume name identifies the volume itself, so it is derived from the resolved resource uid
+	// rather than from the path a container happens to mount it at. Volumes are pod-level and shared
+	// across containers: the same source mounted by two containers must collapse to one volume no
+	// matter which paths they use, and two different sources must not collide just because they are
+	// mounted at the same path. The mount path stays a per-container property of the mount below.
+	sourceHash := sha256.Sum256([]byte(resolvedVolumeSource))
+	volName := fmt.Sprintf("vol-%x", sourceHash[:5])
 	mount := coreV1.VolumeMount{
 		Name:      volName,
 		MountPath: target,
 		SubPath:   internal.DerefOr(volume.Path, ""),
 		ReadOnly:  internal.DerefOr(volume.ReadOnly, false),
-	}
-
-	resolvedVolumeSource, err := framework.SubstituteString(volume.Source, substitutionFunc)
-	if err != nil {
-		return mount, nil, nil, errors.Wrap(err, "source: failed to resolve placeholder")
 	}
 
 	res, ok := resources[framework.ResourceUid(resolvedVolumeSource)]

--- a/internal/convert/container_volumes_test.go
+++ b/internal/convert/container_volumes_test.go
@@ -108,14 +108,14 @@ func Test_convertContainerVolume_nominal_source(t *testing.T) {
 		},
 	}, noSubstitutesFunction)
 	assert.Equal(t, coreV1.VolumeMount{
-		Name:      "vol-274e5357eb",
+		Name:      "vol-c7571c543f",
 		ReadOnly:  true,
 		MountPath: "/mount/path",
 		SubPath:   "sub",
 	}, mount)
 	if assert.NotNil(t, vol) {
 		assert.Equal(t, coreV1.Volume{
-			Name: "vol-274e5357eb",
+			Name: "vol-c7571c543f",
 			VolumeSource: coreV1.VolumeSource{
 				EmptyDir: &coreV1.EmptyDirVolumeSource{
 					SizeLimit: internal.Ref(resource.MustParse("10Mi")),
@@ -142,7 +142,7 @@ func Test_convertContainerVolume_nominal_claim(t *testing.T) {
 		},
 	}, noSubstitutesFunction)
 	assert.Equal(t, coreV1.VolumeMount{
-		Name:      "vol-274e5357eb",
+		Name:      "vol-c7571c543f",
 		ReadOnly:  true,
 		MountPath: "/mount/path",
 		SubPath:   "sub",
@@ -151,7 +151,7 @@ func Test_convertContainerVolume_nominal_claim(t *testing.T) {
 	if assert.NotNil(t, claim) {
 		assert.Equal(t, coreV1.PersistentVolumeClaim{
 			ObjectMeta: v1.ObjectMeta{
-				Name: "vol-274e5357eb",
+				Name: "vol-c7571c543f",
 			},
 			Spec: coreV1.PersistentVolumeClaimSpec{
 				StorageClassName: internal.Ref("default"),

--- a/internal/convert/workloads.go
+++ b/internal/convert/workloads.go
@@ -122,7 +122,12 @@ func ConvertWorkload(state *project.State, workloadName string) ([]machineryMeta
 					if kind != WorkloadKindStatefulSet {
 						return nil, errors.Wrapf(err, "containers.%s.volumes.%s: volume claims can only be set on stateful sets", containerName, target)
 					}
-					volumeClaimTemplates = append(volumeClaimTemplates, *claim)
+					// Claim names follow the same identity as volume names, so a claim-backed volume
+					// mounted by several containers resolves to one template that must be emitted once.
+					volumeClaimTemplates, err = appendVolumeClaimTemplates(volumeClaimTemplates, *claim)
+					if err != nil {
+						return nil, errors.Wrapf(err, "containers.%s.volumes.%s", containerName, target)
+					}
 				} else if vol != nil {
 					containerVolumes = append(containerVolumes, *vol)
 				}
@@ -297,7 +302,7 @@ func ConvertWorkload(state *project.State, workloadName string) ([]machineryMeta
 
 // appendPodVolumes adds the given container-level volumes to the pod-level volume list,
 // collapsing volumes that are shared across containers. Volume names are deterministic
-// (derived from the mount target or resource), so a volume mounted by multiple containers
+// (derived from the identity of the volume source), so a volume mounted by multiple containers
 // yields the same name each time; it must be emitted only once. A name that maps to two
 // genuinely different volume definitions is a conflict and returns an error.
 func appendPodVolumes(volumes []coreV1.Volume, additions []coreV1.Volume) ([]coreV1.Volume, error) {
@@ -311,6 +316,21 @@ func appendPodVolumes(volumes []coreV1.Volume, additions []coreV1.Volume) ([]cor
 		volumes = append(volumes, add)
 	}
 	return volumes, nil
+}
+
+// appendVolumeClaimTemplates adds a persistent volume claim template to the stateful set's list,
+// skipping it when the same claim has already been added by another container. Claim names carry
+// the identity of the volume source, so several containers mounting one claim-backed volume produce
+// the same template repeatedly and Kubernetes rejects a stateful set that lists it more than once.
+// Two different specs under one name are a genuine conflict and return an error.
+func appendVolumeClaimTemplates(claims []coreV1.PersistentVolumeClaim, add coreV1.PersistentVolumeClaim) ([]coreV1.PersistentVolumeClaim, error) {
+	if i := slices.IndexFunc(claims, func(c coreV1.PersistentVolumeClaim) bool { return c.Name == add.Name }); i >= 0 {
+		if !reflect.DeepEqual(claims[i], add) {
+			return nil, errors.Errorf("volume claim '%s' is mounted by multiple containers with conflicting definitions", add.Name)
+		}
+		return claims, nil
+	}
+	return append(claims, add), nil
 }
 
 func WorkloadServiceName(workloadName string, specMetadata map[string]interface{}) string {

--- a/internal/convert/workloads_test.go
+++ b/internal/convert/workloads_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/apps/v1"
+	coreV1 "k8s.io/api/core/v1"
+	machineryMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/score-spec/score-k8s/internal"
@@ -230,7 +232,7 @@ spec:
             cpu: 999m
         volumeMounts:
         - mountPath: /mount/thing
-          name: vol-5e3859fe72
+          name: vol-75c4252512
         - mountPath: /
           name: proj-vol-0
           readOnly: true
@@ -239,7 +241,7 @@ spec:
         resources: {}
       volumes:
       - emptyDir: {}
-        name: vol-5e3859fe72
+        name: vol-75c4252512
       - name: proj-vol-0
         projected:
           sources:
@@ -317,5 +319,228 @@ func TestSharedVolumeAcrossContainers(t *testing.T) {
 	for _, c := range deployment.Spec.Template.Spec.Containers {
 		require.Len(t, c.VolumeMounts, 1)
 		assert.Contains(t, names, c.VolumeMounts[0].Name)
+	}
+}
+
+// buildVolumeWorkloadState builds a workload state with a `vol` resource per entry in resourceNames,
+// each backed by an emptyDir, so the volume identity tests below can stay focused on the mounts.
+func buildVolumeWorkloadState(t *testing.T, containers map[string]scoretypes.Container, resourceNames ...string) *project.State {
+	t.Helper()
+	resources := make(map[string]scoretypes.Resource, len(resourceNames))
+	for _, name := range resourceNames {
+		resources[name] = scoretypes.Resource{Type: "vol", Class: internal.Ref("default")}
+	}
+	state := new(project.State)
+	state, err := state.WithWorkload(&scoretypes.Workload{
+		Metadata:   map[string]interface{}{"name": "example"},
+		Containers: containers,
+		Resources:  resources,
+	}, nil, project.WorkloadExtras{})
+	require.NoError(t, err)
+
+	state.Resources = map[framework.ResourceUid]framework.ScoreResourceState[project.ResourceExtras]{}
+	for _, name := range resourceNames {
+		state.Resources[framework.ResourceUid("vol.default#example."+name)] = framework.ScoreResourceState[project.ResourceExtras]{
+			Type:  "vol",
+			Class: "default",
+			Outputs: map[string]interface{}{
+				"source": map[string]interface{}{"emptyDir": map[string]interface{}{}},
+			},
+		}
+	}
+	return state
+}
+
+func deploymentFrom(t *testing.T, manifests []machineryMeta.Object) *v1.Deployment {
+	t.Helper()
+	for _, m := range manifests {
+		if d, ok := m.(*v1.Deployment); ok {
+			return d
+		}
+	}
+	t.Fatal("no Deployment found in manifests")
+	return nil
+}
+
+// TestSharedVolumeAcrossDifferentMountPaths covers the shared-emptydir-diff-mountpoint case from
+// https://github.com/score-spec/score-k8s/issues/367: one volume resource mounted by two containers
+// at two different paths is a single shared volume, not two independent ones. Volume names used to
+// be derived from the mount path, so the two paths produced two separate emptyDirs.
+func TestSharedVolumeAcrossDifferentMountPaths(t *testing.T) {
+	state := buildVolumeWorkloadState(t, map[string]scoretypes.Container{
+		"main": {
+			Image:   "busybox",
+			Volumes: map[string]scoretypes.ContainerVolume{"/one": {Source: "${resources.data}"}},
+		},
+		"sidecar": {
+			Image:   "busybox",
+			Volumes: map[string]scoretypes.ContainerVolume{"/two": {Source: "${resources.data}"}},
+		},
+	}, "data")
+
+	manifests, err := ConvertWorkload(state, "example")
+	require.NoError(t, err)
+	deployment := deploymentFrom(t, manifests)
+
+	volumes := deployment.Spec.Template.Spec.Volumes
+	require.Len(t, volumes, 1, "one source mounted at two paths must be a single pod-level volume")
+
+	// Both containers mount that one volume, each keeping its own mount path.
+	mountPaths := map[string]string{}
+	for _, c := range deployment.Spec.Template.Spec.Containers {
+		require.Len(t, c.VolumeMounts, 1)
+		assert.Equal(t, volumes[0].Name, c.VolumeMounts[0].Name, "both containers must reference the shared volume")
+		mountPaths[c.Name] = c.VolumeMounts[0].MountPath
+	}
+	assert.Equal(t, map[string]string{"main": "/one", "sidecar": "/two"}, mountPaths)
+}
+
+// TestDistinctVolumesAtSameMountPath covers the diff-emptydir-same-mountpoint case from the same
+// issue: two different volume resources mounted at the same path in two containers are two distinct
+// volumes. Deriving the name from the mount path silently collapsed them into one, so a container
+// ended up reading a volume it never asked for.
+func TestDistinctVolumesAtSameMountPath(t *testing.T) {
+	state := buildVolumeWorkloadState(t, map[string]scoretypes.Container{
+		"main": {
+			Image:   "busybox",
+			Volumes: map[string]scoretypes.ContainerVolume{"/data": {Source: "${resources.vol-01}"}},
+		},
+		"sidecar": {
+			Image:   "busybox",
+			Volumes: map[string]scoretypes.ContainerVolume{"/data": {Source: "${resources.vol-02}"}},
+		},
+	}, "vol-01", "vol-02")
+
+	manifests, err := ConvertWorkload(state, "example")
+	require.NoError(t, err)
+	deployment := deploymentFrom(t, manifests)
+
+	require.Len(t, deployment.Spec.Template.Spec.Volumes, 2, "two different sources must stay two volumes")
+
+	mounted := map[string]string{}
+	for _, c := range deployment.Spec.Template.Spec.Containers {
+		require.Len(t, c.VolumeMounts, 1)
+		assert.Equal(t, "/data", c.VolumeMounts[0].MountPath)
+		mounted[c.Name] = c.VolumeMounts[0].Name
+	}
+	assert.NotEqual(t, mounted["main"], mounted["sidecar"], "distinct sources must not share a volume name")
+
+	names := []string{deployment.Spec.Template.Spec.Volumes[0].Name, deployment.Spec.Template.Spec.Volumes[1].Name}
+	assert.Contains(t, names, mounted["main"])
+	assert.Contains(t, names, mounted["sidecar"])
+}
+
+// TestSharedVolumeKeepsPerContainerMountOptions checks that collapsing to one pod-level volume does
+// not flatten the mount options: subPath and readOnly belong to the mount, not to the volume.
+func TestSharedVolumeKeepsPerContainerMountOptions(t *testing.T) {
+	state := buildVolumeWorkloadState(t, map[string]scoretypes.Container{
+		"writer": {
+			Image: "busybox",
+			Volumes: map[string]scoretypes.ContainerVolume{
+				"/data": {Source: "${resources.data}", Path: internal.Ref("in")},
+			},
+		},
+		"reader": {
+			Image: "busybox",
+			Volumes: map[string]scoretypes.ContainerVolume{
+				"/data": {Source: "${resources.data}", Path: internal.Ref("out"), ReadOnly: internal.Ref(true)},
+			},
+		},
+	}, "data")
+
+	manifests, err := ConvertWorkload(state, "example")
+	require.NoError(t, err)
+	deployment := deploymentFrom(t, manifests)
+
+	require.Len(t, deployment.Spec.Template.Spec.Volumes, 1, "the same source must collapse to one volume")
+
+	mounts := map[string]coreV1.VolumeMount{}
+	for _, c := range deployment.Spec.Template.Spec.Containers {
+		require.Len(t, c.VolumeMounts, 1)
+		mounts[c.Name] = c.VolumeMounts[0]
+	}
+	assert.Equal(t, "in", mounts["writer"].SubPath)
+	assert.False(t, mounts["writer"].ReadOnly)
+	assert.Equal(t, "out", mounts["reader"].SubPath)
+	assert.True(t, mounts["reader"].ReadOnly, "readOnly must stay per container")
+	assert.Equal(t, mounts["writer"].Name, mounts["reader"].Name)
+}
+
+// TestSharedVolumeMountedTwiceInOneContainer checks the single container variant: mounting one
+// source at two paths inside the same container is legal, and must still yield one pod volume.
+func TestSharedVolumeMountedTwiceInOneContainer(t *testing.T) {
+	state := buildVolumeWorkloadState(t, map[string]scoretypes.Container{
+		"main": {
+			Image: "busybox",
+			Volumes: map[string]scoretypes.ContainerVolume{
+				"/one": {Source: "${resources.data}"},
+				"/two": {Source: "${resources.data}"},
+			},
+		},
+	}, "data")
+
+	manifests, err := ConvertWorkload(state, "example")
+	require.NoError(t, err)
+	deployment := deploymentFrom(t, manifests)
+
+	require.Len(t, deployment.Spec.Template.Spec.Volumes, 1, "one source is one pod volume even when mounted twice")
+	require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+	mounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
+	require.Len(t, mounts, 2, "the container keeps both mount points")
+	assert.Equal(t, mounts[0].Name, mounts[1].Name)
+	assert.ElementsMatch(t, []string{"/one", "/two"}, []string{mounts[0].MountPath, mounts[1].MountPath})
+}
+
+// TestSharedVolumeClaimAcrossContainers is the claim-backed counterpart: now that claim names follow
+// the volume source rather than the mount path, two containers mounting one claim produce the same
+// template twice, and a stateful set listing a claim template twice is rejected by Kubernetes.
+func TestSharedVolumeClaimAcrossContainers(t *testing.T) {
+	state := new(project.State)
+	state, err := state.WithWorkload(&scoretypes.Workload{
+		Metadata: map[string]interface{}{
+			"name":        "example",
+			"annotations": map[string]interface{}{internal.WorkloadKindAnnotation: WorkloadKindStatefulSet},
+		},
+		Containers: map[string]scoretypes.Container{
+			"main": {
+				Image:   "busybox",
+				Volumes: map[string]scoretypes.ContainerVolume{"/one": {Source: "${resources.data}"}},
+			},
+			"sidecar": {
+				Image:   "busybox",
+				Volumes: map[string]scoretypes.ContainerVolume{"/two": {Source: "${resources.data}"}},
+			},
+		},
+		Resources: map[string]scoretypes.Resource{
+			"data": {Type: "vol", Class: internal.Ref("default")},
+		},
+	}, nil, project.WorkloadExtras{})
+	require.NoError(t, err)
+	state.Resources = map[framework.ResourceUid]framework.ScoreResourceState[project.ResourceExtras]{
+		"vol.default#example.data": {
+			Type:  "vol",
+			Class: "default",
+			Outputs: map[string]interface{}{
+				"claimSpec": map[string]interface{}{"storageClassName": "default"},
+			},
+		},
+	}
+
+	manifests, err := ConvertWorkload(state, "example")
+	require.NoError(t, err)
+
+	var statefulSet *v1.StatefulSet
+	for _, m := range manifests {
+		if s, ok := m.(*v1.StatefulSet); ok {
+			statefulSet = s
+		}
+	}
+	require.NotNil(t, statefulSet)
+
+	require.Len(t, statefulSet.Spec.VolumeClaimTemplates, 1, "a shared claim must produce a single volume claim template")
+	claimName := statefulSet.Spec.VolumeClaimTemplates[0].Name
+	for _, c := range statefulSet.Spec.Template.Spec.Containers {
+		require.Len(t, c.VolumeMounts, 1)
+		assert.Equal(t, claimName, c.VolumeMounts[0].Name, "both containers must reference the shared claim")
 	}
 }


### PR DESCRIPTION
#### Description

Volume names in the generated PodSpec were derived from the container's mount path rather than from the volume itself:

```go
targetHash := sha256.Sum256([]byte(target))
volName := fmt.Sprintf("vol-%x", targetHash[:5])
```

Volumes in a pod are pod-level and shared across containers, while mount paths are a per-container property. Naming a pod-level object after a per-container one produces the two failure modes described in #367.

This PR resolves the volume source first and derives the name from the resolved resource uid, so a volume keeps one identity no matter how many containers mount it or which paths they use. The mount path stays where it belongs, on the mount.

#### What does this PR do?

Fixes both cases from the issue. Verified against all three Score files in the description, before and after:

| Score file | Expected | Before | After |
|---|---|---|---|
| `shared-emptydir-same-mountpoint` | 1 shared volume | 1 ✅ | 1 ✅ |
| `shared-emptydir-diff-mountpoint` | 1 shared volume | 2 ❌ | 1 ✅ |
| `diff-emptydir-same-mountpoint` | 2 distinct volumes | 1 ❌ | 2 ✅ |

The third case was failing silently. Two different resources hashed to the same name, their definitions compared equal, and the pod-level dedupe added in #366 quietly merged them so a container mounted a volume it never asked for, with no error. That is the collision reported in #327, which this also closes.

It also dedupes `volumeClaimTemplates`. That list had no dedupe, which was harmless while names came from mount paths, but once names follow the source, two containers mounting one claim-backed volume emit the same template twice and Kubernetes rejects the StatefulSet. `appendVolumeClaimTemplates` mirrors the existing `appendPodVolumes`, including its conflicting-definition error.

The `vol-` and `file-` prefixes and the 5-byte hex hash are unchanged, per the discussion in the issue. Only the hash input changed, and only for `vol-`. `file-` is untouched, since for files the target path genuinely is the identity.

**Tests:** five new cases in `internal/convert/workloads_test.go` covering the issue's scenarios plus the per-container `subPath` / `readOnly` and single-container variants, and the claim dedupe. Four of the five fail if the fix is reverted. Two existing golden hashes were updated pure name churn, confirmed to be exactly `sha256(resource-uid)[:5]`.

**Note for the release notes:** re-running `generate` on an existing Score file will produce different `vol-` IDs, as discussed in the issue. Worth calling out that for StatefulSets this also renames the `volumeClaimTemplate`, and since Kubernetes names PVCs `<claim>-<statefulset>-<ordinal>`, a re-apply will bind fresh PVCs and leave the previous ones orphaned rather than reusing them.

Fixes #367
Fixes #327

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [x] I've signed off with an email address that matches the commit author.